### PR TITLE
Fix PDP10 TOD drift

### DIFF
--- a/PDP10/pdp10_tim.c
+++ b/PDP10/pdp10_tim.c
@@ -292,7 +292,7 @@ tim_new_period = new_interval & ~TIM_HWRE_MASK;
 if (new_interval & TIM_HWRE_MASK) tim_new_period += 010000;
     
 /* clk_tps is the new number of clocks ticks per second */
-clk_tps = ceil((double)TIM_HW_FREQ /(double)tim_new_period);
+clk_tps = (int32) ceil((double)TIM_HW_FREQ /(double)tim_new_period);
    
 /* tmxr is polled every tim_mult clks.  Compute the divisor matching the target. */
 tim_mult = (clk_tps <= TIM_TMXR_FREQ) ? 1 : (clk_tps / TIM_TMXR_FREQ) ;


### PR DESCRIPTION
The previous change used milliseconds and truncated the values to that precision. This causes an accumulative drift betweem the TOD value and the wall time, aproximately 1-2 hours each day. This change fixes that, while the runtime computation is also correct.

WARNING: There are still issues with the PDP clock. The jobs with intensive IO get incorrect "time limit exhausted" aborts; I'm still working on that but I'm afraid there is no easy solution unless the clock service moves to an asynchronous model, or to base itself in the host RTC.

This fixes issue #114 
