### PR TITLE
SDS: Fix intermittent I/O data errors when two or more I/O channels acti...

### DIFF
--- a/SDS/sds_io.c
+++ b/SDS/sds_io.c
@@ -55,7 +55,7 @@
 
 #define I_GETDEV3(x)    ((((x) & 020046000) != 020046000)? ((x) & DEV_MASK): DEV_MASK)
 
-#define TST_XFR(d,c)    (xfr_req && dev_map[d][c])
+#define TST_XFR(d,c)    (xfr_req & dev_map[d][c])
 #define SET_XFR(d,c)    xfr_req = xfr_req | dev_map[d][c]
 #define CLR_XFR(d,c)    xfr_req = xfr_req & ~dev_map[d][c]
 #define INV_DEV(d,c)    (dev_dsp[d][c] == NULL)


### PR DESCRIPTION
...ve

When reading from paper tape on the W channel and writing the drum on the E channel, intermittent errors and premature end-of-record were observed. The TST_XFR macro was failing to properly quality that a data character was available for a particular device and channel. Thus, a data ready condition for the drum would cause a bad transfer for another active device on a different channel.