### PR TITLE
SDS: Fix overflow test instructions OVT and OTO

### DIFF
--- a/SDS/sds_cpu.c
+++ b/SDS/sds_cpu.c
@@ -969,7 +969,7 @@ switch (op) {                                           /* case on opcode */
 /* Overflow instruction */
 
     case OVF:
-        if ((inst & 0100) & OV)
+        if ((inst & 0100) && !OV)
             P = (P + 1) & VA_MASK;
         if (inst & 0001)
             OV = 0;


### PR DESCRIPTION
Improper implementation of the OVT and OTO instructions. OV is always zero or one, so the Boolean AND in the  original if statement would always fail. Also, these instructions are supposed to skip if overflow is not set, the opposite of the way it was coded.