### PR TITLE
SDS: Do not stop simulator on paper tape reader error

### DIFF
--- a/SDS/sds_stddev.c
+++ b/SDS/sds_stddev.c
@@ -42,7 +42,7 @@
 extern uint32 xfr_req;
 extern int32 stop_invins, stop_invdev, stop_inviop;
 int32 ptr_sor = 0;                                      /* start of rec */
-int32 ptr_stopioe = 1;                                  /* stop on err */
+int32 ptr_stopioe = 0;                                  /* no stop on err */
 int32 ptp_ldr = 0;                                      /* no leader */
 int32 ptp_stopioe = 1;
 DSPT std_tplt[] = { { 1, 0 }, { 0, 0 }  };              /* template */


### PR DESCRIPTION
The simulator stops when reading past EOF on the paper tape device's attached disk file (or if no file is attached to this device). The SDS timesharing system is capable of processing an end-of-record interrupt in these circumstances, resulting in proper error reporting to the user program that is reading paper tape.