### PR TITLE
SDS: Adjust communication MUX inter-character timing

### DIFF
--- a/SDS/sds_mux.c
+++ b/SDS/sds_mux.c
@@ -50,7 +50,7 @@
 #define MUX_SCANMAX     (MUX_LINES * MUX_FLAGS)         /* flags to scan */
 #define MUX_SCANMASK    (MUX_SCANMAX - 1)
 #define MUX_INIT_POLL   8000
-#define MUXL_WAIT       500
+#define MUXL_WAIT       250
 #define MUX_SETFLG(l,x) mux_flags[((l) * MUX_FLAGS) + (x)] = 1
 #define MUX_SETINT(x)   int_req = int_req | (INT_MUXR >> (x))
 #define MUX_CLRINT(x)   int_req = int_req & ~(INT_MUXR >> (x))


### PR DESCRIPTION
When stuffing the LOGOUT command to a pseudo-teletype, the command script processing program CCP encountered a race condition because the MUX timing was too slow.  The pseudo-teletype did not reliably log off as desired. Cutting the event wait time in half fixed the problem.