### PR TITLE
Added section for centos

### DIFF
--- a/0readme_ethernet.txt
+++ b/0readme_ethernet.txt
@@ -86,6 +86,11 @@ Linux (Fedora Core 18, 20, etc.):
     yum install libpcap-devel
     yum install uml-utilities
 
+Linux (Centos 6.x):
+    yum install gcc
+    yum install libpcap-devel
+    yum install uml_utilities
+    
 OpenBSD (OpenBSD 4.6)
 
     /sbin/ifconfig tun0 create


### PR DESCRIPTION
The uml utilties package is part of EPEL and named uml_utilities and not uml-utilities.
