### PR TITLE
makefile: cygwin build video support using SDL2 (preferred) or SDL

### DIFF
--- a/makefile
+++ b/makefile
@@ -414,6 +414,10 @@ ifeq ($(WIN32),)  #*nix Environments (&& cygwin)
     endif
   endif
   ifneq (,$(VIDEO_USEFUL))
+    ifeq (cygwin,$(OSTYPE))
+      LIBEXTSAVE := $(LIBEXT)
+      LIBEXT = dll.a
+    endif
     ifneq (,$(call find_include,SDL2/SDL))
       ifneq (,$(call find_lib,SDL2))
         VIDEO_CCDEFS += -DHAVE_LIBSDL -I$(dir $(call find_include,SDL2/SDL))
@@ -436,6 +440,9 @@ ifeq ($(WIN32),)  #*nix Environments (&& cygwin)
           endif
         endif
       endif
+    endif
+    ifeq (cygwin,$(OSTYPE))
+      LIBEXT = $(LIBEXTSAVE)
     endif
     ifeq (,$(findstring HAVE_LIBSDL,$(VIDEO_CCDEFS)))
       $(info *** Info ***)


### PR DESCRIPTION
cygwin now includes development packages for the SDL2 and SDL video
libraries (libSDL2-devel and libSDL-devel). Adjust makefile to find the
libSDL2.dll.a or libSDL.dll.a library.