### PR TITLE
SCP: Simh crashes if fclose(NULL) is called

### DIFF
--- a/VAX/vax730_sys.c
+++ b/VAX/vax730_sys.c
@@ -35,7 +35,7 @@
 #include "vax_defs.h"
 
 #ifdef DONT_USE_INTERNAL_ROM
-#define BOOT_CODE_FILENAME "vmb.exe"
+#define BOOT_CODE_FILENAME "vmb.boot"
 #define BOOT_CODE_ARRAY NULL
 #define BOOT_CODE_SIZE 0
 #else /* !DONT_USE_INTERNAL_ROM */

--- a/VAX/vax750_cmi.c
+++ b/VAX/vax750_cmi.c
@@ -34,7 +34,7 @@
 #include "vax_defs.h"
 
 #ifdef DONT_USE_INTERNAL_ROM
-#define BOOT_CODE_FILENAME "vmb.exe"
+#define BOOT_CODE_FILENAME "vmb.boot"
 #else /* !DONT_USE_INTERNAL_ROM */
 #include "vax_vmb_exe.h" /* Defines BOOT_CODE_FILENAME and BOOT_CODE_ARRAY, etc */
 #endif /* DONT_USE_INTERNAL_ROM */

--- a/VAX/vax780_sbi.c
+++ b/VAX/vax780_sbi.c
@@ -39,7 +39,7 @@
 #include "vax_defs.h"
 
 #ifdef DONT_USE_INTERNAL_ROM
-#define BOOT_CODE_FILENAME "vmb.exe"
+#define BOOT_CODE_FILENAME "vmb.boot"
 #else /* !DONT_USE_INTERNAL_ROM */
 #include "vax_vmb_exe.h" /* Defines BOOT_CODE_FILENAME and BOOT_CODE_ARRAY, etc */
 #endif /* DONT_USE_INTERNAL_ROM */

--- a/VAX/vax860_abus.c
+++ b/VAX/vax860_abus.c
@@ -32,7 +32,7 @@
 #include "vax_defs.h"
 
 #ifdef DONT_USE_INTERNAL_ROM
-#define BOOT_CODE_FILENAME "vmb.exe"
+#define BOOT_CODE_FILENAME "vmb.boot"
 #else /* !DONT_USE_INTERNAL_ROM */
 #include "vax_vmb_exe.h" /* Defines BOOT_CODE_FILENAME and BOOT_CODE_ARRAY, etc */
 #endif /* DONT_USE_INTERNAL_ROM */

--- a/VAX/vax_vmb_exe.h
+++ b/VAX/vax_vmb_exe.h
@@ -2,12 +2,12 @@
 #define ROM_vax_vmb_exe_H 0
 /*
    VAX/vax_vmb_exe.h         produced at Sun Mar 24 16:38:01 2013
-   from VAX/vmb.exe which was last modified at Sun Mar 24 12:24:51 2013
+   from VAX/vmb.boot which was last modified at Sun Mar 24 12:24:51 2013
    file size: 44544 (0xAE00) - checksum: 0xFFC014BB
    This file is a generated file and should NOT be edited or changed by hand.
 */
 #define BOOT_CODE_SIZE 0xAE00
-#define BOOT_CODE_FILENAME "vmb.exe"
+#define BOOT_CODE_FILENAME "vmb.boot"
 #define BOOT_CODE_ARRAY vax_vmb_exe
 unsigned char vax_vmb_exe[] = {
 0xD4,0xEF,0x34,0x61,0x00,0x00,0x17,0xEF,0xB8,0x5D,0x00,0x00,0xC1,0xAB,0x38,0xAB,

--- a/scp.c
+++ b/scp.c
@@ -5443,8 +5443,10 @@ if (uptr->flags & UNIT_BUF) {
 uptr->flags = uptr->flags & ~(UNIT_ATT | UNIT_RO);
 free (uptr->filename);
 uptr->filename = NULL;
-if (fclose (uptr->fileref) == EOF)
-    return SCPE_IOERR;
+if (uptr->fileref != NULL) {  /* Sometimes this can be null! */
+    if (fclose (uptr->fileref) == EOF)
+        return SCPE_IOERR;
+    }
 return SCPE_OK;
 }
 

--- a/sim_console.h
+++ b/sim_console.h
@@ -73,6 +73,7 @@ void sim_remote_process_command (void);
 t_stat sim_set_kmap (int32 flag, char *cptr);
 t_stat sim_set_telnet (int32 flag, char *cptr);
 t_stat sim_set_notelnet (int32 flag, char *cptr);
+t_stat sim_set_client (int32 flag, char *cptr);
 t_stat sim_set_serial (int32 flag, char *cptr);
 t_stat sim_set_noserial (int32 flag, char *cptr);
 t_stat sim_set_logon (int32 flag, char *cptr);
@@ -93,6 +94,7 @@ t_stat sim_show_console (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *c
 t_stat sim_show_remote_console (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
 t_stat sim_show_kmap (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
 t_stat sim_show_telnet (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
+t_stat sim_show_client (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
 t_stat sim_show_log (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
 t_stat sim_show_debug (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);
 t_stat sim_show_pchar (FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, char *cptr);

--- a/sim_rev.h
+++ b/sim_rev.h
@@ -37,7 +37,7 @@
 #define SIM_PATCH       0
 #endif
 #ifndef SIM_DELTA
-#define SIM_DELTA       0
+#define SIM_DELTA       1
 #endif
 
 #ifndef SIM_VERSION_MODE


### PR DESCRIPTION
I remember getting this in previous versions and I fixed it locally. Now I've seen it's still here in the latest code. I can't reproduce the NULL pointer, though, but it *did* happen (under vax simulation).