### PR TITLE
slirp_glue: cleanup compiler warning for redefinition of O_BINARY

### DIFF
--- a/slirp_glue/qemu/qemu-common.h
+++ b/slirp_glue/qemu/qemu-common.h
@@ -18,6 +18,10 @@
 #include "glib.h"
 #include "config-host.h"
 
+#if defined(O_BINARY)   /* O_BINARY isn't used in slirp */
+#undef O_BINARY         /* Avoid potential redefinition elsewhere */
+#endif
+
 /* HOST_LONG_BITS is the size of a native pointer in bits. */
 #if UINTPTR_MAX == UINT32_MAX
 # define HOST_LONG_BITS 32


### PR DESCRIPTION
Compilation under Cygwin was giving the warning
slirp/slirp.h:24:0: warning: "O_BINARY" redefined
#  define O_BINARY 0
^
In file included from /usr/include/sys/fcntl.h:3:0,
from /usr/include/fcntl.h:15,
from slirp_glue/qemu/osdep.h:57,
from slirp_glue/qemu/qemu-common.h:15,
from slirp/slirp.c:24:
/usr/include/sys/_default_fcntl.h:56:0: note: this is the location of
the previous definition
#define O_BINARY _FBINARY