### PR TITLE
VAX: Fix external type definition for BadCmPSL that was preventing compilation under HP C V7.3-009 on OpenVMS Alpha V8.3

### DIFF
--- a/VAX/vax_defs.h
+++ b/VAX/vax_defs.h
@@ -853,7 +853,7 @@ extern int32 op_octa (int32 *opnd, int32 cc, int32 opc, int32 acc, int32 spec, i
 
 /* vax_cmode.c externals */
 extern int32 op_cmode (int32 cc);
-extern int32 BadCmPSL (int32 newpsl);
+extern t_bool BadCmPSL (int32 newpsl);
 
 /* vax_sys.c externals */
 extern const uint16 drom[NUM_INST][MAX_SPEC + 1];


### PR DESCRIPTION
Fix external type definition of BadCmPSL in vax_defs.h to match the definition in vax_cmode.c so that compilation under HP C V7.3-009 on OpenVMS Alpha V8.3 does not bork with a NOTCOMPAT error.  Also verified that the change does not affect compilation under Linux, Mac OS X and Cygwin.

(Extract from logfile building VAX with MMK)
$! Building The SYS$DISK:[.BIN.VMS.LIB]VAXL1-AXP.OLB Library.
$!
$ RUN/NODEBUG SYS$DISK:[.BIN]BuildROMs-AXP.EXE
$ CC/DECC/PREF=ALL/DEBUG/OPT=(LEV=5)/ARCH=HOST  /NEST=PRIMARY/NAME=(AS_IS,SHORT)
/INCL=(SYS$DISK:[],SYS$DISK:[.VAX],SYS$DISK:[.PDP11],SYS$DISK:[-.PCAP-VMS.PCAP-V
CI]) /DEF=("_LARGEFILE","SIM_ASYNCH_IO=1","VM_VAX=1","USE_ADDR64=1","USE_INT64=1
","USE_NETWORK=1","HAVE_PCAP_NETWORK=1")/OBJ=SYS$DISK:[.VAX]  /OBJ=SYS$DISK:[.BI
N.VMS.LIB.BLD-AXP] SYS$DISK:[.VAX]VAX_CIS.C,SYS$DISK:[.VAX]VAX_CMODE.C,SYS$DISK:
[.VAX]VAX_CPU.C,SYS$DISK:[.VAX]VAX_CPU1.C,SYS$DISK:[.VAX]VAX_FPA.C,SYS$DISK:[.VA
X]VAX_MMU.C,SYS$DISK:[.VAX]VAX_OCTA.C,SYS$DISK:[.VAX]VAX_SYS.C,SYS$DISK:[.VAX]VA
X_SYSCM.C,SYS$DISK:[.VAX]VAX_SYSDEV.C,SYS$DISK:[.VAX]VAX_SYSLIST.C,SYS$DISK:[.VA
X]VAX_IO.C,SYS$DISK:[.VAX]VAX_STDDEV.C

t_bool BadCmPSL (int32 newpsl)
.......^
%CC-E-NOTCOMPAT, In this declaration, the type of "BadCmPSL" is not compatible with the type of a previous declaration of "BadCmPSL" at line number 856 in file
USER_DISK:[LOCAL.SOURCES.SIMH-MASTER.VAX]VAX_DEFS.H;1.
at line number 1303 in file USER_DISK:[LOCAL.SOURCES.SIMH-MASTER.VAX]VAX_CMODE.C
;1

extern t_bool BadCmPSL (int32 newpsl);
..............^
%CC-E-NOTCOMPAT, In this declaration, the type of "BadCmPSL" is not compatible with the type of a previous declaration of "BadCmPSL" at line number 856 in file
USER_DISK:[LOCAL.SOURCES.SIMH-MASTER.VAX]VAX_DEFS.H;1.
at line number 89 in file USER_DISK:[LOCAL.SOURCES.SIMH-MASTER.VAX]VAX_CPU1.C;1
%MMK-F-ERRUPD, error status %X10B91262 occurred when updating target SYS$DISK:[.
BIN.VMS.LIB]VAXL1-AXP.OLB
  SYSTEM       job terminated at  1-APR-2016 22:00:35.90
