### PR TITLE
PDP11: Record the actual source and destination values.

### DIFF
--- a/PDP11/pdp11_cpu.c
+++ b/PDP11/pdp11_cpu.c
@@ -745,6 +745,7 @@ while (reason == 0)  {
     int32 IR, srcspec, srcreg, dstspec, dstreg;
     int32 src, src2, dst, ea;
     int32 i, t, sign, oldrs, trapnum;
+    InstHistory *hst_ent;
 
     if (cpu_astop) {
         cpu_astop = 0;
@@ -881,20 +882,22 @@ while (reason == 0)  {
             SWMASK ('K') | SWMASK ('V'), SWMASK ('S') | SWMASK ('V'),
             SWMASK ('U') | SWMASK ('V'), SWMASK ('U') | SWMASK ('V')
             };
-        hst[hst_p].pc = PC | HIST_VLD;
-        hst[hst_p].psw = get_PSW ();
-        hst[hst_p].src = R[srcspec & 07];
-        hst[hst_p].dst = R[dstspec & 07];
-        hst[hst_p].inst[0] = IR;
+        hst_ent = &hst[hst_p];
+        hst_ent->pc = PC | HIST_VLD;
+        hst_ent->psw = get_PSW ();
+        hst_ent->src = 0;
+        hst_ent->dst = 0;
+        hst_ent->inst[0] = IR;
         for (i = 1; i < HIST_ILNT; i++) {
             if (cpu_ex (&val, (PC + (i << 1)) & 0177777, &cpu_unit, swmap[cm & 03]))
-                hst[hst_p].inst[i] = 0;
-            else hst[hst_p].inst[i] = (uint16) val;
+                hst_ent->inst[i] = 0;
+            else hst_ent->inst[i] = (uint16) val;
             }
         hst_p = (hst_p + 1);
         if (hst_p >= hst_lnt)
             hst_p = 0;
         }
+    else hst_ent = NULL;
     PC = (PC + 2) & 0177777;                            /* incr PC, mod 65k */
     switch ((IR >> 12) & 017) {                         /* decode IR<15:12> */
 
@@ -983,6 +986,8 @@ while (reason == 0)  {
                 if (CPUT (CPUT_05|CPUT_20) &&           /* 11/05, 11/20 */
                     ((dstspec & 070) == 020))           /* JMP (R)+? */
                     dst = R[dstspec & 07];              /* use post incr */
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 JMP_PC (dst);
                 }
             break;                                      /* end JMP */
@@ -990,6 +995,8 @@ while (reason == 0)  {
         case 002:                                       /* RTS et al*/
             if (IR < 000210) {                          /* RTS */
                 dstspec = dstspec & 07;
+                if (hst_ent)
+                    hst_ent->dst = R[dstspec];
                 JMP_PC (R[dstspec]);
                 R[dstspec] = ReadW (SP | dsenable);
                 if (dstspec != 6)
@@ -1038,6 +1045,8 @@ while (reason == 0)  {
             if (!CPUT (CPUT_20))
                 V = 0;
             C = 0;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1138,6 +1147,8 @@ while (reason == 0)  {
                 if ((cm == MD_KER) && (SP < (STKLIM + STKL_Y)))
                     set_stack_trap (SP);
                 R[srcspec] = PC;
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 JMP_PC (dst & 0177777);
                 }
             break;                                      /* end JSR */
@@ -1145,6 +1156,8 @@ while (reason == 0)  {
         case 050:                                       /* CLR */
             N = V = C = 0;
             Z = 1;
+            if (hst_ent)
+                hst_ent->dst = 0;
             if (dstreg)
                 R[dstspec] = 0;
             else WriteW (0, GeteaW (dstspec));
@@ -1157,6 +1170,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             V = 0;
             C = 1;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1168,6 +1183,8 @@ while (reason == 0)  {
             N = GET_SIGN_W (dst);
             Z = GET_Z (dst);
             V = (dst == 0100000);
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1179,6 +1196,8 @@ while (reason == 0)  {
             N = GET_SIGN_W (dst);
             Z = GET_Z (dst);
             V = (dst == 077777);
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1191,6 +1210,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             V = (dst == 0100000);
             C = Z ^ 1;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1203,6 +1224,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             V = (C && (dst == 0100000));
             C = C & Z;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1215,6 +1238,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             V = (C && (dst == 077777));
             C = (C && (dst == 0177777));
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1222,6 +1247,8 @@ while (reason == 0)  {
 
         case 057:                                       /* TST */
             dst = dstreg? R[dstspec]: ReadW (GeteaW (dstspec));
+            if (hst_ent)
+                hst_ent->dst = dst;
             N = GET_SIGN_W (dst);
             Z = GET_Z (dst);
             V = C = 0;
@@ -1234,6 +1261,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             C = (src & 1);
             V = N ^ C;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1246,6 +1275,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             C = GET_SIGN_W (src);
             V = N ^ C;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1258,6 +1289,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             C = (src & 1);
             V = N ^ C;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1270,6 +1303,8 @@ while (reason == 0)  {
             Z = GET_Z (dst);
             C = GET_SIGN_W (src);
             V = N ^ C;
+            if (hst_ent)
+                hst_ent->dst = dst;
             if (dstreg)
                 R[dstspec] = dst;
             else PWriteW (dst, last_pa);
@@ -1307,6 +1342,8 @@ while (reason == 0)  {
                 SP = (SP - 2) & 0177777;
                 if (update_MM)
                     MMR1 = calc_MMR1 (0366);
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 WriteW (dst, SP | dsenable);
                 if ((cm == MD_KER) && (SP < (STKLIM + STKL_Y)))
                     set_stack_trap (SP);
@@ -1322,6 +1359,8 @@ while (reason == 0)  {
                 V = 0;
                 SP = (SP + 2) & 0177777;
                 if (update_MM) MMR1 = 026;
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 if (dstreg) {
                     if ((dstspec == 6) && (cm != pm))
                         STACKFILE[pm] = dst;
@@ -1337,6 +1376,8 @@ while (reason == 0)  {
                 dst = N? 0177777: 0;
                 Z = N ^ 1;
                 V = 0;
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 if (dstreg)
                     R[dstspec] = dst;
                 else WriteW (dst, GeteaW (dstspec));
@@ -1371,6 +1412,8 @@ while (reason == 0)  {
                 V = 0;
                 C = (dst & 1);
                 R[0] = dst;                             /* R[0] <- dst */
+                if (hst_ent)
+                    hst_ent->dst = dst | 1;
                 PWriteW (R[0] | 1, last_pa);            /* dst <- R[0] | 1 */
                 }
             else setTRAP (TRAP_ILL);
@@ -1382,6 +1425,8 @@ while (reason == 0)  {
                 Z = GET_Z (R[0]);
                 V = 0;
                 WriteW (R[0], GeteaW (dstspec));
+                if (hst_ent)
+                    hst_ent->dst = R[0];
                 }
             else setTRAP (TRAP_ILL);
             break;
@@ -1416,6 +1461,10 @@ while (reason == 0)  {
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = 0;
+        if (hst_ent) {
+            hst_ent->src = dst;
+            hst_ent->dst = dst;
+            }
         if (dstreg)
             R[dstspec] = dst;
         else WriteW (dst, ea);
@@ -1431,6 +1480,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadW (GeteaW (dstspec));
             }
         dst = (src - src2) & 0177777;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = src2;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = GET_SIGN_W ((src ^ src2) & (~src2 ^ dst));
@@ -1447,6 +1500,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadW (GeteaW (dstspec));
             }
         dst = src2 & src;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -1462,6 +1519,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMW (GeteaW (dstspec));
             }
         dst = src2 & ~src;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -1480,6 +1541,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMW (GeteaW (dstspec));
             }
         dst = src2 | src;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -1498,6 +1563,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMW (GeteaW (dstspec));
             }
         dst = (src2 + src) & 0177777;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = GET_SIGN_W ((~src ^ src2) & (src ^ dst));
@@ -1540,6 +1609,10 @@ while (reason == 0)  {
             if (GET_SIGN_W (src))
                 src = src | ~077777;
             dst = src * src2;
+            if (hst_ent) {
+                hst_ent->src = src;
+                hst_ent->dst = dst;
+                }
             R[srcspec] = (dst >> 16) & 0177777;
             R[srcspec | 1] = dst & 0177777;
             N = (dst < 0);
@@ -1570,6 +1643,10 @@ while (reason == 0)  {
             if (GET_SIGN_W (R[srcspec]))
                 src = src | ~017777777777;
             dst = src / src2;
+            if (hst_ent) {
+                hst_ent->src = src;
+                hst_ent->dst = dst;
+                }
             N = (dst < 0);                              /* N set on 32b result */
             if ((dst > 077777) || (dst < -0100000)) {
                 V = 1;                                  /* J11,11/70 compat */
@@ -1616,6 +1693,10 @@ while (reason == 0)  {
                 V = 0;
                 C = ((src >> (63 - src2)) & 1);
                 }
+            if (hst_ent) {
+                hst_ent->src = src;
+                hst_ent->dst = dst;
+                }
             dst = R[srcspec] = dst & 0177777;
             N = GET_SIGN_W (dst);
             Z = GET_Z (dst);
@@ -1651,6 +1732,10 @@ while (reason == 0)  {
                 C = ((src >> (63 - src2)) & 1);
                 }
             i = R[srcspec] = (dst >> 16) & 0177777;
+            if (hst_ent) {
+                hst_ent->src = src;
+                hst_ent->dst = dst;
+                }
             dst = R[srcspec | 1] = dst & 0177777;
             N = GET_SIGN_W (i);
             Z = GET_Z (dst | i);
@@ -1667,6 +1752,10 @@ while (reason == 0)  {
                     src2 = dstreg? R[dstspec]: ReadMW (GeteaW (dstspec));
                     }
                 dst = src ^ src2;
+                if (hst_ent) {
+                    hst_ent->src = src;
+                    hst_ent->dst = dst;
+                    }
                 N = GET_SIGN_W (dst);
                 Z = GET_Z (dst);
                 V = 0;
@@ -1697,6 +1786,8 @@ while (reason == 0)  {
         case 7:                                         /* SOB */
             if (CPUT (HAS_SXS)) {
                 R[srcspec] = (R[srcspec] - 1) & 0177777;
+                if (hst_ent)
+                    hst_ent->dst = R[srcspec];
                 if (R[srcspec]) {
                     JMP_PC ((PC - dstspec - dstspec) & 0177777);
                     }
@@ -1821,6 +1912,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = R[dstspec] & 0177400;
             else WriteB (0, GeteaB (dstspec));
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = 0;
+            }
             break;
 
         case 051:                                       /* COMB */
@@ -1833,6 +1929,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 052:                                       /* INCB */
@@ -1844,6 +1945,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 053:                                       /* DECB */
@@ -1855,6 +1961,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 054:                                       /* NEGB */
@@ -1867,6 +1978,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 055:                                       /* ADCB */
@@ -1879,6 +1995,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 056:                                       /* SBCB */
@@ -1891,10 +2012,17 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 057:                                       /* TSTB */
             dst = dstreg? R[dstspec] & 0377: ReadB (GeteaB (dstspec));
+            if (hst_ent)
+                hst_ent->dst = dst;
             N = GET_SIGN_B (dst);
             Z = GET_Z (dst);
             V = C = 0;
@@ -1910,6 +2038,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 061:                                       /* ROLB */
@@ -1922,6 +2055,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 062:                                       /* ASRB */
@@ -1934,6 +2072,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
         case 063:                                       /* ASLB */
@@ -1946,6 +2089,11 @@ while (reason == 0)  {
             if (dstreg)
                 R[dstspec] = (R[dstspec] & 0177400) | dst;
             else PWriteB (dst, last_pa);
+            if (hst_ent) {
+                if (dstreg)
+                    hst_ent->dst = R[dstspec];
+                else hst_ent->dst = dst;
+            }
             break;
 
 /* Notes:
@@ -1983,6 +2131,8 @@ while (reason == 0)  {
                 SP = (SP - 2) & 0177777;
                 if (update_MM)
                     MMR1 = calc_MMR1 (0366);
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 WriteW (dst, SP | dsenable);
                 if ((cm == MD_KER) && (SP < (STKLIM + STKL_Y)))
                     set_stack_trap (SP);
@@ -1999,6 +2149,8 @@ while (reason == 0)  {
                 SP = (SP + 2) & 0177777;
                 if (update_MM)
                     MMR1 = 026;
+                if (hst_ent)
+                    hst_ent->dst = dst;
                 if (dstreg) {
                     if ((dstspec == 6) && (cm != pm))
                         STACKFILE[pm] = dst;
@@ -2050,6 +2202,10 @@ while (reason == 0)  {
         if (dstreg)
             R[dstspec] = (dst & 0200)? 0177400 | dst: dst;
         else WriteB (dst, ea);
+        if (hst_ent) {
+            hst_ent->src = srcreg? R[srcspec]: dst;
+            hst_ent->dst = dstreg? R[dstspec]: dst;
+            }
         break;
 
     case 012:                                           /* CMPB */
@@ -2060,6 +2216,10 @@ while (reason == 0)  {
         else {
             src = srcreg? R[srcspec] & 0377: ReadB (GeteaB (srcspec));
             src2 = dstreg? R[dstspec] & 0377: ReadB (GeteaB (dstspec));
+            }
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = src2;
             }
         dst = (src - src2) & 0377;
         N = GET_SIGN_B (dst);
@@ -2078,6 +2238,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec] & 0377: ReadB (GeteaB (dstspec));
             }
         dst = (src2 & src) & 0377;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_B (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -2093,6 +2257,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMB (GeteaB (dstspec));
             }
         dst = (src2 & ~src) & 0377;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_B (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -2111,6 +2279,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMB (GeteaB (dstspec));
             }
         dst = (src2 | src) & 0377;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_B (dst);
         Z = GET_Z (dst);
         V = 0;
@@ -2129,6 +2301,10 @@ while (reason == 0)  {
             src2 = dstreg? R[dstspec]: ReadMW (GeteaW (dstspec));
             }
         dst = (src2 - src) & 0177777;
+        if (hst_ent) {
+            hst_ent->src = src;
+            hst_ent->dst = dst;
+            }
         N = GET_SIGN_W (dst);
         Z = GET_Z (dst);
         V = GET_SIGN_W ((src ^ src2) & (~src ^ dst));


### PR DESCRIPTION
Previously, the history would always use a register value as source or
destination as if the mode were zero, even when it wasn't.  Also, now
the destination value reflects the destination after instruction
execution rather than before.