### PR TITLE
VIDEO: don't flip mouse button state while mouse moves

### DIFF
--- a/sim_video.c
+++ b/sim_video.c
@@ -1214,7 +1214,7 @@ while (SDL_PeepEvents (&dummy_event, 1, SDL_GETEVENT, SDL_MOUSEMOTION, SDL_MOUSE
     event->yrel += dev->yrel;
     event->x = dev->x;
     event->y = dev->y;
-    event->state ^= dev->state;
+//  event->state ^= dev->state;
     sim_debug (SIM_VID_DBG_MOUSE, vid_dev, "Mouse Move Event: Additional Event Coalesced:pos:(%d,%d) rel:(%d,%d) buttons:(%d,%d,%d)\n", 
         dev->x, dev->y, dev->xrel, dev->yrel, (dev->state & SDL_BUTTON(SDL_BUTTON_LEFT)) ? 1 : 0, (dev->state & SDL_BUTTON(SDL_BUTTON_MIDDLE)) ? 1 : 0, (dev->state & SDL_BUTTON(SDL_BUTTON_RIGHT)) ? 1 : 0);
     };


### PR DESCRIPTION
This makes dragging an outline of new window work in DMD 5620 sim.