### PR TITLE
BESM6: Fixed a bug in multiplication.

### DIFF
--- a/BESM6/besm6_arith.c
+++ b/BESM6/besm6_arith.c
@@ -364,7 +364,7 @@ void besm6_multiply (t_value val)
 
     acc.mantissa = l + ahi * bhi;
 
-    if (neg) {
+    if (neg && (acc.mantissa || mr)) {
         mr = (~mr & BITS40) + 1;
         acc.mantissa = ((~acc.mantissa & BITS40) + (mr >> 40))
             | BIT41 | BIT42;


### PR DESCRIPTION
Multiplying a negative number by a zero value with a non-zero exponent produced wrong results.
This was not caught by the bringup test of the ALU, and was only discovered recently. 