### PR TITLE
PDP11: Fix setting of CSR address in RF11 boot command.

### DIFF
--- a/PDP11/pdp11_rf.c
+++ b/PDP11/pdp11_rf.c
@@ -440,7 +440,7 @@ return auto_config (0, 0);
 
 #define BOOT_START      02000                           /* start */
 #define BOOT_ENTRY      (BOOT_START + 002)              /* entry */
-#define BOOT_CSR        (BOOT_START + 032)              /* CSR */
+#define BOOT_CSR        (BOOT_START + 010)              /* CSR */
 #define BOOT_LEN        (sizeof (boot_rom) / sizeof (uint16))
 
 static const uint16 boot_rom[] = {


### PR DESCRIPTION
I found this while playing with the V3 RSTS tapes on Bitsavers, which are for RF system disk.