### PR TITLE
PDP11: Correct the address of MMR3 in a comment

### DIFF
--- a/PDP11/pdp11_cpu.c
+++ b/PDP11/pdp11_cpu.c
@@ -3072,7 +3072,7 @@ return pa;
    MMR0 17777572        read/write, certain bits unimplemented or read only
    MMR1 17777574        read only
    MMR2 17777576        read only
-   MMR3 17777516        read/write, certain bits unimplemented
+   MMR3 17772516        read/write, certain bits unimplemented
 */
 
 t_stat MMR012_rd (int32 *data, int32 pa, int32 access)


### PR DESCRIPTION
Only changed the address of MMR3 in a comment.  No actual code changes.