### PR TITLE
Soft Power-Off and Critical MMU fix

### DIFF
--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -105,6 +105,7 @@ noret __libc_longjmp (jmp_buf buf, int val);
 #define STOP_EX             5     /* Exception */
 #define STOP_ESTK           6     /* Exception stack too deep */
 #define STOP_MMU            7     /* Unimplemented MMU Feature */
+#define STOP_POWER          8     /* System power-off */
 
 /* Exceptional conditions handled within the instruction loop */
 #define ABORT_EXC           1      /* CPU exception  */

--- a/3B2/3b2_iu.c
+++ b/3B2/3b2_iu.c
@@ -66,6 +66,9 @@ IU_PORT iu_contty;
 /* The timer state */
 IU_TIMER_STATE iu_timer_state;
 
+/* The power flag */
+t_bool iu_killpower = FALSE;
+
 /* Flags for incrementing mode pointers */
 t_bool iu_increment_a = FALSE;
 t_bool iu_increment_b = FALSE;
@@ -632,6 +635,12 @@ void iu_write(uint32 pa, uint32 val, size_t size)
         sim_debug(EXECUTE_MSG, &contty_dev,
                   ">>> SOPR written: %02x\n",
                   (uint8) val);
+        /* Bit 2 of the IU output register is used as a soft power
+         * switch. When set, the machine will power down
+         * immediately. */
+        if (val & IU_KILLPWR) {
+            stop_reason = STOP_POWER;
+        }
         break;
     case ROPR:
         sim_debug(EXECUTE_MSG, &contty_dev,

--- a/3B2/3b2_iu.c
+++ b/3B2/3b2_iu.c
@@ -66,9 +66,6 @@ IU_PORT iu_contty;
 /* The timer state */
 IU_TIMER_STATE iu_timer_state;
 
-/* The power flag */
-t_bool iu_killpower = FALSE;
-
 /* Flags for incrementing mode pointers */
 t_bool iu_increment_a = FALSE;
 t_bool iu_increment_b = FALSE;

--- a/3B2/3b2_iu.h
+++ b/3B2/3b2_iu.h
@@ -113,6 +113,9 @@
 #define UM_MASK       0x70
 #define UM_SHIFT      4
 
+/* Power-off bit */
+#define IU_KILLPWR    0x04
+
 #define PORT_A            0
 #define PORT_B            1
 

--- a/3B2/3b2_sys.c
+++ b/3B2/3b2_sys.c
@@ -72,7 +72,8 @@ const char *sim_stop_messages[] = {
     "IRQ",
     "Exception/Trap",
     "Exception Stack Too Deep",
-    "Unimplemented MMU Feature"
+    "Unimplemented MMU Feature",
+    "System Powered Off"
 };
 
 void full_reset()


### PR DESCRIPTION
Two commits:

1. Soft power-off, providing support for the emulator to power itself off via a software command, as in the real 3B2/400.

2. Fix for a critical MMU bug that had been lurking undetected for a surprisingly long time, but prevented C-Kermit from being compiled.