### PR TITLE
3b2: CONTTY line configuration

### DIFF
--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -333,6 +333,9 @@ extern DEVICE dmac_dev;
 /* global symbols from the CSR */
 extern uint16 csr_data;
 
+/* global symbols from the timer */
+extern int32 tmxr_poll;
+
 /* global symbols from the IU */
 extern t_bool iu_increment_a;
 extern t_bool iu_increment_b;

--- a/3B2/3b2_iu.h
+++ b/3B2/3b2_iu.h
@@ -113,6 +113,13 @@
 #define UM_MASK       0x70
 #define UM_SHIFT      4
 
+/* IMR bits */
+#define IMR_TXRA      0x01
+#define IMR_RXRA      0x02
+#define IMR_CTR       0x08
+#define IMR_TXRB      0x10
+#define IMR_RXRB      0x20
+
 /* Power-off bit */
 #define IU_KILLPWR    0x04
 
@@ -150,6 +157,8 @@ extern DEVICE iu_timer_dev;
 
 #define IU_DCDA           0x01
 #define IU_DCDB           0x02
+#define IU_DTRA           0x01
+#define IU_DTRB           0x02
 
 typedef struct iu_port {
     uint8 stat;               /* Port Status */
@@ -189,7 +198,7 @@ t_stat contty_reset(DEVICE *dptr);
 t_stat iu_timer_reset(DEVICE *dptr);
 t_stat iu_svc_tti(UNIT *uptr);
 t_stat iu_svc_tto(UNIT *uptr);
-t_stat iu_svc_contty(UNIT *uptr);
+t_stat iu_svc_contty_rcv(UNIT *uptr);
 t_stat iu_svc_contty_xmt(UNIT *uptr);
 t_stat iu_svc_timer(UNIT *uptr);
 uint32 iu_read(uint32 pa, size_t size);

--- a/3B2/3b2_sysdev.c
+++ b/3B2/3b2_sysdev.c
@@ -59,6 +59,8 @@ uint32 *NVRAM = NULL;
 
 extern DEVICE cpu_dev;
 
+int32 tmxr_poll = 0;
+
 /* CSR */
 
 uint16 csr_data;
@@ -486,7 +488,7 @@ t_stat timer0_svc(UNIT *uptr)
 t_stat timer1_svc(UNIT *uptr)
 {
     struct timer_ctr *ctr;
-    int32 ticks;
+    int32 ticks, t;
 
     ctr = (struct timer_ctr *)uptr->tmr;
 
@@ -501,8 +503,9 @@ t_stat timer1_svc(UNIT *uptr)
         ticks = TPS_CLK;
     }
 
-    sim_rtcn_calb(ticks, TMR_CLK);
+    t = sim_rtcn_calb(ticks, TMR_CLK);
     sim_activate_after(uptr, (uint32) (1000000 / ticks));
+    tmxr_poll = t;
 
     return SCPE_OK;
 }


### PR DESCRIPTION
Adds modem control line speed configuration to prevent FIFO overflow.