### PR TITLE
3b2: Fix warnings generated by older GCC

### DIFF
--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -343,7 +343,6 @@ extern void increment_modep_a();
 extern void increment_modep_b();
 
 /* global symbols from the MMU */
-extern t_bool mmu_enabled();
 extern void mmu_enable();
 extern void mmu_disable();
 extern uint8 read_b(uint32 va, uint8 acc);

--- a/3B2/3b2_if.c
+++ b/3B2/3b2_if.c
@@ -517,7 +517,7 @@ void if_write(uint32 pa, uint32 val, size_t size)
 /*
  * Compute the offset of the currently selected C/H/S
  */
-SIM_INLINE uint32 if_buf_offset()
+static SIM_INLINE uint32 if_buf_offset()
 {
     uint32 pos;
 

--- a/3B2/3b2_if.h
+++ b/3B2/3b2_if.h
@@ -127,12 +127,12 @@ extern t_bool if_irq;
 static SIM_INLINE void if_set_irq();
 static SIM_INLINE void if_clear_irq();
 static SIM_INLINE void if_cancel_pending_irq();
+static SIM_INLINE uint32 if_buf_offset();
 t_stat if_svc(UNIT *uptr);
 t_stat if_reset(DEVICE *dptr);
 uint32 if_read(uint32 pa, size_t size);
 void if_write(uint32 pa, uint32 val, size_t size);
 void if_drq_handled();
 void if_handle_command();
-uint32 if_buf_offset();
 
 #endif

--- a/3B2/3b2_mmu.c
+++ b/3B2/3b2_mmu.c
@@ -681,7 +681,7 @@ t_stat mmu_decode_va(uint32 va, uint8 r_acc, t_bool fc, uint32 *pa)
     uint8 pd_acc;
     t_stat sd_cached, pd_cached;
 
-    if (!mmu_enabled()) {
+    if (!mmu_state.enabled) {
         *pa = va;
         return SCPE_OK;
     }
@@ -824,11 +824,6 @@ uint32 mmu_xlate_addr(uint32 va, uint8 r_acc)
         cpu_abort(NORMAL_EXCEPTION, EXTERNAL_MEMORY_FAULT);
         return 0;
     }
-}
-
-SIM_INLINE t_bool mmu_enabled()
-{
-    return mmu_state.enabled;
 }
 
 void mmu_enable()


### PR DESCRIPTION
GCC 4.1.2 produced several warnings about inline functions.
This commit fixes those warnings.