### PR TITLE
3b2: Allow handling of TRACE and BREAKPOINT traps

### DIFF
--- a/3B2/3b2_cpu.h
+++ b/3B2/3b2_cpu.h
@@ -85,6 +85,7 @@
  * Opcodes
  */
 typedef enum {
+    HALT    = 0x00, /* Undocumented instruction */
     SPOPRD  = 0x02,
     SPOPD2  = 0x03,
     MOVAW   = 0x04,

--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -124,14 +124,15 @@ noret __libc_longjmp (jmp_buf buf, int val);
 #define C_STACK_FAULT        9
 
 /* Debug flags */
-#define READ_MSG     0x01
-#define WRITE_MSG    0x02
-#define DECODE_MSG   0x04
-#define EXECUTE_MSG  0x08
-#define INIT_MSG     0x10
-#define IRQ_MSG      0x20
-#define IO_D_MSG     0x40
-#define TRACE_MSG    0x80
+#define READ_MSG     0x001
+#define WRITE_MSG    0x002
+#define DECODE_MSG   0x004
+#define EXECUTE_MSG  0x008
+#define INIT_MSG     0x010
+#define IRQ_MSG      0x020
+#define IO_D_MSG     0x040
+#define TRACE_MSG    0x080
+#define ERR_MSG      0x100
 
 /* Data types operated on by instructions. NB: These integer values
    have meaning when decoding instructions, so this is not just an

--- a/3B2/3b2_iu.c
+++ b/3B2/3b2_iu.c
@@ -302,7 +302,7 @@ t_stat contty_reset(DEVICE *dtpr)
 
     memset(&iu_state, 0, sizeof(IU_STATE));
     memset(&iu_contty, 0, sizeof(IU_PORT));
-    tmxr_set_config_line(&contty_ldsc[0], "115200-8N1");
+    tmxr_set_config_line(&contty_ldsc[0], "9600-8N1");
 
     /* Start the CONTTY polling loop */
     if (!sim_is_active(contty_rcv_unit)) {


### PR DESCRIPTION
The 3B2 emulator did not have support for traps, rendering debugging
under the simulator fairly useless. This change adds support for
trap handling. The 'sdb' UNIX debugger under SVR3 should now work
correctly.