### PR TITLE
3b2: Prevent attempts to ex/dep IO

### DIFF
--- a/3B2/3b2_cpu.c
+++ b/3B2/3b2_cpu.c
@@ -571,12 +571,13 @@ t_stat cpu_ex(t_value *vptr, t_addr addr, UNIT *uptr, int32 sw)
         *vptr = value;
         return succ;
     } else {
-        if (!(addr_is_rom(uaddr) || addr_is_mem(uaddr) || addr_is_io(uaddr))) {
+        if (addr_is_rom(uaddr) || addr_is_mem(uaddr)) {
+            *vptr = (uint32) pread_b(uaddr);
+            return SCPE_OK;
+        } else {
             *vptr = 0;
             return SCPE_NXM;
         }
-        *vptr = (uint32) pread_b(uaddr);
-        return SCPE_OK;
     }
 }
 
@@ -587,11 +588,12 @@ t_stat cpu_dep(t_value val, t_addr addr, UNIT *uptr, int32 sw)
     if (sw & EX_V_FLAG) {
         return deposit(uaddr, (uint8) val);
     } else {
-        if (!(addr_is_rom(uaddr) || addr_is_mem(uaddr) || addr_is_io(uaddr))) {
+        if (addr_is_mem(uaddr)) {
+            pwrite_b(uaddr, (uint8) val);
+            return SCPE_OK;
+        } else {
             return SCPE_NXM;
         }
-        pwrite_b(uaddr, (uint8) val);
-        return SCPE_OK;
     }
 }
 

--- a/3B2/3b2_mmu.c
+++ b/3B2/3b2_mmu.c
@@ -764,7 +764,7 @@ t_stat examine(uint32 va, uint8 *val) {
     succ = mmu_decode_va(va, 0, FALSE, &pa);
 
     if (succ == SCPE_OK) {
-        if (addr_is_rom(pa) || addr_is_io(pa) || addr_is_mem(pa)) {
+        if (addr_is_rom(pa) || addr_is_mem(pa)) {
             *val = pread_b(pa);
             return SCPE_OK;
         } else {
@@ -784,7 +784,7 @@ t_stat deposit(uint32 va, uint8 val) {
     succ = mmu_decode_va(va, 0, FALSE, &pa);
 
     if (succ == SCPE_OK) {
-        if (addr_is_mem(pa) || addr_is_io(pa)) {
+        if (addr_is_mem(pa)) {
             pwrite_b(pa, val);
             return SCPE_OK;
         } else {


### PR DESCRIPTION
This fix prevents several cases when writing or reading I/O can cause nasty side effects.