### PR TITLE
Install prerequisite libraries for Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ os:
   - linux
   - osx
 language: c
+sudo: required
+install: sh -ex .travis/deps.sh
 script: make all

--- a/.travis/deps.sh
+++ b/.travis/deps.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+install_osx() {
+    brew install sdl2
+    brew install vde
+}
+
+install_linux() {
+    sudo apt-get update -yqqm
+    sudo apt-get install -ym libegl1-mesa-dev libgles2-mesa-dev
+    sudo apt-get install -ym libsdl2-dev libpcap-dev libvdeplug-dev
+    sudo apt-get install -ym libsdl2-ttf-dev
+}
+
+install_"$TRAVIS_OS_NAME"


### PR DESCRIPTION
This install some prerequisite  libraries for the Travis CI build.

For an unknown reason I had to install libegl1-mesa-dev and libgles2-mesa-dev too to make apt happy.