### PR TITLE
AltairZ80: Set conditional under CYGWIN so the SIMH device works

### DIFF
--- a/AltairZ80/altairz80_defs.h
+++ b/AltairZ80/altairz80_defs.h
@@ -83,7 +83,7 @@ typedef enum {
 #define UNIT_CPU_V_SWITCHER     (UNIT_V_UF+6)               /* switcher 8086 <--> 8080/Z80 enabled          */
 #define UNIT_CPU_SWITCHER       (1 << UNIT_CPU_V_SWITCHER)
 
-#if defined (__linux) || defined (__linux__) || defined(__NetBSD__) || defined (__OpenBSD__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__hpux)
+#if defined (__linux) || defined (__linux__) || defined(__NetBSD__) || defined (__OpenBSD__) || defined (__FreeBSD__) || defined (__APPLE__) || defined (__hpux) || defined (__CYGWIN__)
 #define UNIX_PLATFORM 1
 #else
 #define UNIX_PLATFORM 0


### PR DESCRIPTION
Under CYGWIN the conditional tests in the altairz80_sio.c source file for the SIMH pseudo device's getHostsFilenamesCmd and resetSIMHInterfaceCmd functions need to have UNIX_PLATFORM set to 1 - otherwise they do nothing! With this fix, the HDIR host command from CP/M now displays a list of files in host system's current directory under CYGWIN.