### PR TITLE
3b2: Refactor DUART and DMA

### DIFF
--- a/3B2/3b2_cpu.c
+++ b/3B2/3b2_cpu.c
@@ -1,4 +1,4 @@
-/* 3b2_cpu.c: AT&T 3B2 Model 400 CPU (WE32100) Implementation
+ /* 3b2_cpu.c: AT&T 3B2 Model 400 CPU (WE32100) Implementation
 
    Copyright (c) 2017, Seth J. Morabito
 

--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -329,6 +329,40 @@ extern t_bool cpu_km;
 typedef void (*callback)(void);
 
 /* global symbols from the DMAC */
+typedef struct {
+    uint8  page;
+    uint16 addr;     /* Original addr       */
+    uint16 wcount;   /* Original wcount     */
+    uint16 addr_c;   /* Current addr        */
+    int32  wcount_c; /* Current word-count  */
+    uint16 ptr;      /* Pointer into memory */
+} dma_channel;
+
+typedef struct {
+    /* Byte (high/low) flip-flop */
+    uint8  bff;
+
+    /* Address and count registers for channels 0-3 */
+    dma_channel channels[4];
+
+    /* DMAC programmable registers */
+    uint8 command;
+    uint8 mode;
+    uint8 request;
+    uint8 mask;
+    uint8 status;
+} DMA_STATE;
+
+extern DMA_STATE dma_state;
+
+static SIM_INLINE uint32 dma_address(uint8 channel, uint32 offset, t_bool r) {
+    uint32 addr;
+    addr = (PHYS_MEM_BASE + dma_state.channels[channel].addr + offset);
+    /* The top bit of the page address is a R/W bit, so we mask it here */
+    addr |= (uint32) (((uint32)dma_state.channels[channel].page & 0x7f) << 16);
+    return addr;
+}
+
 extern DEVICE dmac_dev;
 
 /* global symbols from the CSR */

--- a/3B2/3b2_dmac.h
+++ b/3B2/3b2_dmac.h
@@ -72,42 +72,19 @@
 
 #define DMA_IF_READ      (IFBASE + IF_DATA_REG)
 
-
-typedef struct {
-    uint8  page;
-    uint16 addr;     /* Original addr      */
-    uint16 wcount;   /* Original wcount    */
-    uint16 addr_c;   /* Current addr       */
-    uint16 wcount_c; /* Current word-count */
-} dma_channel;
-
-typedef struct {
-    /* Byte (high/low) flip-flop */
-    uint8  bff;
-
-    /* Address and count registers for channels 0-3 */
-    dma_channel channels[4];
-
-    /* DMAC programmable registers */
-    uint8 command;
-    uint8 mode;
-    uint8 request;
-    uint8 mask;
-    uint8 status;
-} DMA_STATE;
-
 typedef struct {
     uint8  channel;
     uint32 service_address;
     t_bool *drq;
-    void  (*handled_callback)();
-} dmac_drq_handler;
+    void  (*dma_handler)(uint8 channel, uint32 service_address);
+    void  (*after_dma_callback)();
+} dmac_dma_handler;
 
 /* DMAC */
 t_stat dmac_reset(DEVICE *dptr);
 uint32 dmac_read(uint32 pa, size_t size);
 void dmac_write(uint32 pa, uint32 val, size_t size);
 void dmac_service_drqs();
-void dmac_transfer(uint8 channel, uint32 service_address);
+void dmac_generic_dma(uint8 channel, uint32 service_address);
 
 #endif

--- a/3B2/3b2_id.c
+++ b/3B2/3b2_id.c
@@ -939,7 +939,7 @@ void id_handle_command(uint8 val)
     }
 }
 
-void id_drq_handled()
+void id_after_dma()
 {
     id_status &= ~ID_STAT_DRQ;
     id_drq = FALSE;

--- a/3B2/3b2_id.h
+++ b/3B2/3b2_id.h
@@ -155,6 +155,8 @@
 
 #define ID_NUM_UNITS   2
 
+#define DMA_ID_SVC     IDBASE+ID_DATA_REG
+
 extern DEVICE id_dev;
 extern DEBTAB sys_deb_tab[];
 extern t_bool id_drq;
@@ -180,9 +182,8 @@ CONST char *id_description(DEVICE *dptr);
 t_stat id_help(FILE *st, DEVICE *dptr, UNIT *uptr, int32 flag, const char *cptr);
 void id_handle_data(uint8 val);
 void id_handle_command(uint8 val);
+void id_after_dma();
 
 static SIM_INLINE t_lba id_lba(uint16 cyl, uint8 head, uint8 sec);
-
-void id_drq_handled();
 
 #endif

--- a/3B2/3b2_if.c
+++ b/3B2/3b2_if.c
@@ -532,7 +532,8 @@ static SIM_INLINE uint32 if_buf_offset()
     return pos;
 }
 
-void if_drq_handled()
+void if_after_dma()
 {
+    if_state.drq = FALSE;
     if_state.status &= ~IF_DRQ;
 }

--- a/3B2/3b2_if.h
+++ b/3B2/3b2_if.h
@@ -132,7 +132,7 @@ t_stat if_svc(UNIT *uptr);
 t_stat if_reset(DEVICE *dptr);
 uint32 if_read(uint32 pa, size_t size);
 void if_write(uint32 pa, uint32 val, size_t size);
-void if_drq_handled();
 void if_handle_command();
+void if_after_dma();
 
 #endif

--- a/3B2/3b2_iu.c
+++ b/3B2/3b2_iu.c
@@ -335,7 +335,6 @@ t_stat tti_reset(DEVICE *dptr)
 t_stat contty_reset(DEVICE *dtpr)
 {
     char line_config[16];
-    t_stat result;
 
     if (contty_ldsc == NULL) {
         contty_desc.ldsc =

--- a/3B2/3b2_iu.h
+++ b/3B2/3b2_iu.h
@@ -140,6 +140,8 @@ extern DEVICE tto_dev;
 extern DEVICE contty_dev;
 extern DEVICE iu_timer_dev;
 
+extern int32 tmxr_poll;
+
 #define IUBASE            0x49000
 #define IUSIZE            0x100
 
@@ -167,6 +169,11 @@ extern DEVICE iu_timer_dev;
 #define IU_DTRA           0x01
 #define IU_DTRB           0x02
 
+#define DMA_NONE   0
+#define DMA_VERIFY 1
+#define DMA_WRITE  2
+#define DMA_READ   4
+
 /* Default baud rate generator (9600 baud) */
 #define BRG_DEFAULT       11
 
@@ -181,7 +188,8 @@ typedef struct iu_port {
     uint8 rxbuf[IU_BUF_SIZE]; /* Receive Holding Register (3 bytes) */
     uint8 w_p;                /* Buffer Write Pointer */
     uint8 r_p;                /* Buffer Read Pointer */
-    t_bool drq;               /* DRQ enabled */
+    uint8 dma;                /* Currently active DMA mode */
+    t_bool drq;               /* DMA request enabled */
 } IU_PORT;
 
 typedef struct iu_state {
@@ -212,14 +220,15 @@ t_stat iu_svc_tto(UNIT *uptr);
 t_stat iu_svc_contty_rcv(UNIT *uptr);
 t_stat iu_svc_contty_xmt(UNIT *uptr);
 t_stat iu_svc_timer(UNIT *uptr);
+t_stat iu_tx(uint8 portno, uint8 val);
 uint32 iu_read(uint32 pa, size_t size);
 void iu_write(uint32 pa, uint32 val, size_t size);
 void iua_drq_handled();
 void iub_drq_handled();
 void iu_txrdy_a_irq();
 void iu_txrdy_b_irq();
+void iu_dma(uint8 channel, uint32 service_address);
 
-static SIM_INLINE void iu_tx(uint8 portno, uint8 val);
 static SIM_INLINE void iu_w_buf(uint8 portno, uint8 val);
 static SIM_INLINE void iu_w_cmd(uint8 portno, uint8 val);
 static SIM_INLINE void iu_update_rxi(uint8 c);

--- a/3B2/3b2_mmu.c
+++ b/3B2/3b2_mmu.c
@@ -695,8 +695,11 @@ t_stat mmu_decode_va(uint32 va, uint8 r_acc, t_bool fc, uint32 *pa)
         if (fc && mmu_check_perm(SD_ACC(sd0), r_acc) != SCPE_OK) {
             sim_debug(EXECUTE_MSG, &mmu_dev,
                       "[%08x] CONTIGUOUS: NO ACCESS TO MEMORY AT %08x.\n"
+                      "\t\tsd0=%08x sd0_addr=%08x\n"
                       "\t\tcpu_cm=%d acc_req=%x sd_acc=%02x\n",
-                      R[NUM_PC], va, CPU_CM, r_acc, SD_ACC(sd0));
+                      R[NUM_PC], va,
+                      sd0, SD_ADDR(va),
+                      CPU_CM, r_acc, SD_ACC(sd0));
             MMU_FAULT(MMU_F_ACC);
             return SCPE_NXM;
         }

--- a/3B2/3b2_sysdev.c
+++ b/3B2/3b2_sysdev.c
@@ -59,7 +59,7 @@ uint32 *NVRAM = NULL;
 
 extern DEVICE cpu_dev;
 
-int32 tmxr_poll = 0;
+int32 tmxr_poll = 16667;
 
 /* CSR */
 


### PR DESCRIPTION
This change is a major refactor of how DMA and the DUART interact.

DMA implementation can now be overridden by individual devices that
require DMA. Disk and Floppy both continue to use a generic DMA
implementation, but the DUART code replaces the generic DMA with its
own implementation that correctly rate-limits TX. Among other things,
this allows the simulator to work correctly with real serial
terminals. This functionality has been tested on an AT&T 5620 "Blit"
terminal, which can run the 'layers' windowing software from the
simulator.