### PR TITLE
KA10: Fix 340 bug.

### DIFF
--- a/display/type340.c
+++ b/display/type340.c
@@ -453,7 +453,7 @@ vector(int i, int sy, int dy, int sx, int dx)
 {
     struct type340 *u = UNIT(0);
     int x0, y0, x1, y1;
-    int flags;
+    int flags = 0;
 
     DEBUGF(("v i%d y%c%d x%c%d\r\n", i,
             (sy ? '-' : '+'), dy,


### PR DESCRIPTION
In the `vector` function, the `flags` variable isn't initialized.  The function can sometimes return boolean true even though it shouldn't.  This causes the 340 to escape vector mode, with display list havoc as a result.