### PR TITLE
display: Fix X11 crash when DISPLAY unset.

### DIFF
--- a/display/x11.c
+++ b/display/x11.c
@@ -272,6 +272,10 @@ ws_init(const char *crtname,    /* crt type name */
     xpixels = xp;               /* save screen size */
     ypixels = yp;
 
+    if (getenv ("DISPLAY") == NULL) {
+        return 0;
+    }
+
     XtToolkitInitialize();
     app_context = XtCreateApplicationContext();
     argc = 0;


### PR DESCRIPTION
If the DISPLAY environment variable isn't set, the ws_init call to XkbSetDetectableAutoRepeat will crash due to a NULL pointer.