### PR TITLE
TMXR: Add Morton box line speeds: 25k, 40k, 50k, and 80k BPS.

### DIFF
--- a/sim_tmxr.c
+++ b/sim_tmxr.c
@@ -2474,9 +2474,13 @@ static struct {
     {"7200",    TMLN_SPD_7200_BPS},
     {"9600",    TMLN_SPD_9600_BPS},
     {"19200",   TMLN_SPD_19200_BPS},
+    {"25000",   TMLN_SPD_25000_BPS},
     {"38400",   TMLN_SPD_38400_BPS},
+    {"40000",   TMLN_SPD_40000_BPS},
+    {"50000",   TMLN_SPD_50000_BPS},
     {"57600",   TMLN_SPD_57600_BPS},
     {"76800",   TMLN_SPD_76800_BPS},
+    {"80000",   TMLN_SPD_80000_BPS},
     {"115200",  TMLN_SPD_115200_BPS},
     {"0",       0}};                    /* End of List, last valid value */
 int nspeed;

--- a/sim_tmxr.h
+++ b/sim_tmxr.h
@@ -114,9 +114,13 @@ typedef struct SERPORT *SERHANDLE;
 #define TMLN_SPD_7200_BPS     1388 /* usec per character */
 #define TMLN_SPD_9600_BPS     1041 /* usec per character */
 #define TMLN_SPD_19200_BPS     520 /* usec per character */
+#define TMLN_SPD_25000_BPS     400 /* usec per character */
 #define TMLN_SPD_38400_BPS     260 /* usec per character */
+#define TMLN_SPD_40000_BPS     250 /* usec per character */
+#define TMLN_SPD_50000_BPS     200 /* usec per character */
 #define TMLN_SPD_57600_BPS     173 /* usec per character */
 #define TMLN_SPD_76800_BPS     130 /* usec per character */
+#define TMLN_SPD_80000_BPS     125 /* usec per character */
 #define TMLN_SPD_115200_BPS     86 /* usec per character */
 
 


### PR DESCRIPTION
The "Morton box" was a PDP-10 I/O bus device custom made at MIT.  It was a terminal multiplexer supporting high speeds.  In order for a SIMH user to set those speeds, here is a pull request to add 25k, 40k, 50k, and 80k bits/s.