### PR TITLE
Attempting a Panda Display frontpanel

### DIFF
--- a/PDP10/pdp10_cpu.c
+++ b/PDP10/pdp10_cpu.c
@@ -204,6 +204,7 @@ int32 hst_p = 0;                                        /* history pointer */
 int32 hst_lnt = 0;                                      /* history length */
 InstHistory *hst = NULL;                                /* instruction history */
 int32 apr_serial = -1;                                  /* CPU Serial number */
+d10 console_lights = 0;
 
 /* Forward and external declarations */
 
@@ -215,6 +216,8 @@ t_stat cpu_set_hist (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat cpu_show_hist (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 t_stat cpu_set_serial (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat cpu_show_serial (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
+t_stat cpu_set_lights (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
+t_stat cpu_clr_lights (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 
 d10 adjsp (d10 val, a10 ea);
 void ibp (a10 ea, int32 pflgs);
@@ -241,6 +244,7 @@ d10 calc_jrstfea (d10 inst, int32 pflgs);
 void pi_dismiss (void);
 void set_newflags (d10 fl, t_bool jrst);
 extern t_bool aprid (a10 ea, int32 prv);
+t_bool lights (a10 ea, int32 prv);
 t_bool wrpi (a10 ea, int32 prv);
 t_bool rdpi (a10 ea, int32 prv);
 t_bool czpi (a10 ea, int32 prv);
@@ -387,6 +391,7 @@ REG cpu_reg[] = {
     { ORDATAD (WRU, sim_int_char, 8, "interrupt character") },
     { FLDATA (STOP_ILL, stop_op0, 0) },
     { BRDATAD (REG, acs, 8, 36, AC_NUM * AC_NBLK, "register sets") },
+    { ORDATAD (LIGHTS, console_lights, 36, "console lights") },
     { NULL }
     };
 
@@ -404,6 +409,8 @@ MTAB cpu_mod[] = {
     { MTAB_XTD|MTAB_VDV|MTAB_NMO|MTAB_SHP, 0, "HISTORY", "HISTORY",
       &cpu_set_hist, &cpu_show_hist },
     { MTAB_XTD|MTAB_VDV|MTAB_VALR, 0, "SERIAL", "SERIAL", &cpu_set_serial, &cpu_show_serial },
+    { UNIT_LIGHTS, 0,           "NOLIGHTS", "NOLIGHTS", &cpu_clr_lights },
+    { UNIT_LIGHTS, UNIT_LIGHTS, "LIGHTS",   "LIGHTS",   &cpu_set_lights },
     { 0 }
     };
 
@@ -2251,6 +2258,12 @@ set_dyn_ptrs ();                                        /* set new ptrs */
 return;
 }
 
+t_bool lights (a10 ea, int32 prv)
+{
+console_lights = Read (ea, prv);
+return FALSE;
+}
+
 /* Priority interrupt system (PI)
 
    The priority interrupt system has three sources of requests
@@ -2589,5 +2602,17 @@ if( (apr_serial == -1) || (!Q_ITS && apr_serial < 4096) ) {
     return SCPE_OK;
     }
 fprintf (st, "%d", apr_serial);
+return SCPE_OK;
+}
+
+t_stat cpu_set_lights (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
+{
+io700d[11] = lights;
+return SCPE_OK;
+}
+
+t_stat cpu_clr_lights (UNIT *uptr, int32 val, CONST char *cptr, void *desc)
+{
+io700d[11] = NULL;
 return SCPE_OK;
 }

--- a/PDP10/pdp10_defs.h
+++ b/PDP10/pdp10_defs.h
@@ -136,13 +136,16 @@ typedef t_int64         d10;                            /* PDP-10 data (36b) */
 #define UNIT_V_ITS      (UNIT_V_UF)                     /* ITS */
 #define UNIT_V_T20      (UNIT_V_UF + 1)                 /* TOPS-20 */
 #define UNIT_V_KLAD     (UNIT_V_UF + 2)                 /* diagnostics */
+#define UNIT_V_LIGHTS   (UNIT_V_UF + 3)                 /* console lights */
 #define UNIT_ITS        (1 << UNIT_V_ITS)
 #define UNIT_T20        (1 << UNIT_V_T20)
 #define UNIT_KLAD       (1 << UNIT_V_KLAD)
+#define UNIT_LIGHTS     (1 << UNIT_V_LIGHTS)
 #define Q_T10           ((cpu_unit.flags & (UNIT_ITS|UNIT_T20|UNIT_KLAD)) == 0)
 #define Q_ITS           (cpu_unit.flags & UNIT_ITS)
 #define Q_T20           (cpu_unit.flags & UNIT_T20)
 #define Q_KLAD          (cpu_unit.flags & UNIT_KLAD)
+#define Q_LIGHTS        (cpu_unit.flags & UNIT_LIGHTS)
 
 /* Architectural constants */
 
@@ -790,7 +793,6 @@ t_stat show_addr (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 t_stat set_vec (UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 t_stat show_vec (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
 t_stat show_vec_mux (FILE *st, UNIT *uptr, int32 val, CONST void *desc);
-t_stat auto_config (const char *name, int32 num);
 
 extern d10 *ac_cur;                                     /* current AC block */
 extern int32 flags;                                     /* flags */

--- a/frontpanel/Panda.mk
+++ b/frontpanel/Panda.mk
@@ -1,0 +1,6 @@
+CFLAGS=-Wall -I..
+LDFLAGS=-L..
+LIBS=-lusb-1.0 -lpthread
+
+panda: panda.o ../sim_frontpanel.o ../sim_sock.o
+	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)

--- a/frontpanel/panda.c
+++ b/frontpanel/panda.c
@@ -1,0 +1,186 @@
+/* panda.c: Panda Display, PDP-10 console lights.
+
+   Copyright (c) 2018, Lars Brinkhoff
+
+   Permission is hereby granted, free of charge, to any person obtaining a
+   copy of this software and associated documentation files (the "Software"),
+   to deal in the Software without restriction, including without limitation
+   the rights to use, copy, modify, merge, publish, distribute, sublicense,
+   and/or sell copies of the Software, and to permit persons to whom the
+   Software is furnished to do so, subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in
+   all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+   RICHARD CORNWELL BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+   IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <libusb-1.0/libusb.h>
+#include "sim_frontpanel.h"
+
+static libusb_device_handle *lights_handle = NULL;
+static unsigned long long lights_main = 0;
+PANEL *panel;
+
+static void lights_latch (void)
+{
+    unsigned char buffer[8];
+
+    if (lights_handle == NULL)
+        return;
+
+    buffer[0] = (lights_main >> 32) & 0377;
+    buffer[1] = (lights_main >> 24) & 0377;
+    buffer[2] = (lights_main >> 16) & 0377;
+    buffer[3] = (lights_main >> 8) & 0377;
+    buffer[4] = lights_main & 0377;
+
+    buffer[5] = 0;
+    buffer[6] = 0;
+    buffer[7] = 0;
+
+    libusb_control_transfer(lights_handle,
+                            LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_DEVICE | LIBUSB_ENDPOINT_OUT,
+                            LIBUSB_REQUEST_SET_CONFIGURATION,
+                            0x0000,
+                            0,
+                            buffer,
+                            sizeof buffer,
+                            5000);
+}
+
+#define USB_CFG_VENDOR_ID       0xc0, 0x16
+#define USB_CFG_DEVICE_ID       0xdf, 0x05
+#define USB_CFG_DEVICE_NAME     'P','a','n','d','a',' ','D','i','s','p','l','a','y',
+#define USB_CFG_DEVICE_NAME_LEN 13
+
+static libusb_device_handle *get_panda_handle(libusb_device **devs)
+{
+    libusb_device *dev;
+    libusb_device_handle *handle = NULL;
+    int i = 0;
+    int r;
+
+    int found = 0;
+    int openable = 0;
+
+    unsigned char prod[256];
+    char devname[USB_CFG_DEVICE_NAME_LEN] = {USB_CFG_DEVICE_NAME};
+
+    unsigned char   rawVid[2] = {USB_CFG_VENDOR_ID};
+    unsigned char    rawPid[2] = {USB_CFG_DEVICE_ID};
+
+    int vid = rawVid[0] + 256 * rawVid[1];
+    int pid = rawPid[0] + 256 * rawPid[1];
+
+
+    while ((dev = devs[i++]) != NULL) {
+        struct libusb_device_descriptor desc;
+        libusb_get_device_descriptor(dev, &desc); /* this always succeeds */
+        // Do the VID and PID match?
+        if (desc.idVendor == vid && desc.idProduct == pid) {
+            found = 1;
+            r = libusb_open(dev, &handle);
+            // If we can't open it, keep trying.
+            // There may be a device with the same pid and vid but not a Panda Display
+            if (r < 0) {
+                continue;
+            }
+            openable = 1;
+            r = libusb_get_string_descriptor_ascii(handle, desc.iProduct, prod, sizeof prod);
+            if (r < 0) {
+                libusb_close(handle);
+                return NULL;
+            }
+            // Here we have something that matches the free
+            // VID and PID offered by Objective Development.
+            // Now we need to Check device name to see if it
+            // really is a Panda Display.
+            if ((0 == strncmp((char *)prod, devname, USB_CFG_DEVICE_NAME_LEN)) &&
+                (desc.idVendor == vid) &&
+                (desc.idProduct == pid)) {
+                return handle;
+            }
+            libusb_close(handle);
+        }
+    }
+
+    if (found) {
+        if (openable)
+                  fprintf (stderr, "Found USB device matching 16c0:05df, but it isn't a Panda Display\n");
+        else
+                  fprintf (stderr, "Found something that might be a Panda Display, but couldn't open it.\n");
+    }
+
+    return NULL;
+}
+
+void lights_init (void)
+{
+    libusb_device **devs;
+    libusb_context *ctx = NULL;
+    ssize_t cnt;
+    int r;
+
+    if (lights_handle != NULL)
+        return;
+
+    r = libusb_init(&ctx);
+    if (r < 0) {
+        fprintf (stderr, "USB init failed.\n");
+        exit (1);
+    }
+
+    cnt = libusb_get_device_list(ctx, &devs);
+    if (cnt < 0) {
+        fprintf (stderr, "USB device list.\n");
+        exit (1);
+    }
+
+    lights_handle = get_panda_handle(devs);
+    if (lights_handle == NULL)
+        exit (1);
+
+    if (libusb_kernel_driver_active(lights_handle, 0) == 1)
+        libusb_detach_kernel_driver(lights_handle, 0);
+
+    libusb_claim_interface(lights_handle, 0);
+}
+
+void callback (PANEL *panel, unsigned long long time, void *context)
+{
+  lights_latch ();
+}
+
+int main (int argc, char **argv)
+{
+  const char *sim_path = argv[1];
+  const char *sim_config = argv[2];
+
+  lights_init ();
+
+  panel = sim_panel_start_simulator (sim_path, sim_config, 1);
+  if (panel == NULL) {
+    printf ("Error starting: %s\n", sim_panel_get_error());
+    return 1;
+  }
+
+  if (sim_panel_add_register (panel, "LIGHTS",  "CPU",
+                              sizeof(lights_main), &lights_main)) {
+    printf ("Error adding lights: %s\n", sim_panel_get_error());
+    return 1;
+  }
+
+  sim_panel_set_display_callback_interval (panel, callback, NULL, 10000);
+
+  sim_panel_exec_boot (panel, "RP0");
+
+  return 0;
+}


### PR DESCRIPTION
This is a little premature for a pull request, but maybe I can get some input.

This first adds a CPU setting for enabling console lights.  Then an attempt at using this with a frontpanel application for the [Panda Display](https://gitlab.com/DavidGriffith/panda-display).  The frontpanel seems to start the simulator, but nothing happens.  The telnet console is unresponsive.