### PR TITLE
BESM6: Printer file position must be updated.

### DIFF
--- a/BESM6/besm6_printer.c
+++ b/BESM6/besm6_printer.c
@@ -144,6 +144,7 @@ void printer_control (int num, uint32 cmd)
     case 1:         /* linefeed */
         READY &= ~(PRN1_LINEFEED >> num);
         offset_gost_write (num, u->fileref);
+        u->pos = ftell(u->fileref);
         dev->feed = LINEFEED_SYNC;
         break;
     case 4:         /* start */


### PR DESCRIPTION
Why would a *sequential* file need to be re-seeked in scp.c  to the stored position  rather than to the end of file at every restart of the simulation from the CLI is unclear, but a 1-line fix solves the issue.