### PR TITLE
3b2: Properly initialize DMAC Current Word Count

### DIFF
--- a/3B2/3b2_dmac.c
+++ b/3B2/3b2_dmac.c
@@ -79,7 +79,7 @@ t_stat dmac_reset(DEVICE *dptr)
         dma_state.channels[i].addr = 0;
         dma_state.channels[i].wcount = 0;
         dma_state.channels[i].addr_c = 0;
-        dma_state.channels[i].wcount_c = 0;
+        dma_state.channels[i].wcount_c = -1;
         dma_state.channels[i].ptr = 0;
     }
 
@@ -282,7 +282,7 @@ void dmac_program(uint8 reg, uint8 val)
             dma_state.channels[i].addr = 0;
             dma_state.channels[i].wcount = 0;
             dma_state.channels[i].addr_c = 0;
-            dma_state.channels[i].wcount_c = 0;
+            dma_state.channels[i].wcount_c = -1;
             dma_state.channels[i].ptr = 0;
         }
         break;
@@ -372,7 +372,7 @@ void dmac_generic_dma(uint8 channel, uint32 service_address)
     uint32 addr;
     dma_channel *chan = &dma_state.channels[channel];
 
-    i = (int32) chan->wcount_c;
+    i = chan->wcount_c;
 
     /* TODO: This does not handle decrement-mode transfers,
        which don't seem to be used in SVR3 */


### PR DESCRIPTION
The DMAC controller "Current Word Count" expects to decrement beyond 0 to 0xffff. Its initial value should also be 0xffff. Setting the initial value to 0 introduced a very subtle bug related to DUART self-test following a soft power reset.