### PR TITLE
display: Update 340 simulation to use sim_ws.

### DIFF
--- a/display/type340.c
+++ b/display/type340.c
@@ -144,12 +144,12 @@ ty340_set_dac(ty340word addr)
 #endif
 
 ty340word
-ty340_reset(void)
+ty340_reset(void *dptr)
 {
     struct type340 *u = UNIT(0);
 #ifndef TY340_NODISPLAY
     if (!u->initialized) {
-        display_init(DIS_TYPE340, 1, u); /* XXX check return? */
+        display_init(DIS_TYPE340, 1, dptr); /* XXX check return? */
         u->initialized = 1;
     }
 #endif

--- a/display/type340.h
+++ b/display/type340.h
@@ -46,7 +46,7 @@ typedef unsigned int ty340word;
 /*
  * calls from host into type340.c
  */
-ty340word ty340_reset(void);
+ty340word ty340_reset(void *);
 ty340word ty340_status(void);
 ty340word ty340_instruction(ty340word inst);
 void ty340_set_dac(ty340word addr);


### PR DESCRIPTION
I'm not sure if this is appropriate here.  It kind of straddles upstream SIMH (this repo) and @rcornwell's KA10 simulator.

The background is that I want the Type 340 simulation to use sim_ws.c instead of x11.c.  This is because I want the new `vid_display_kb_event_process` API.

To do this, I need to pass the SIMH dptr from the KA10 simulator, to `display_init` which will in turn pass it on to `ws_init`.  The sim_ws `ws_init` expects the dptr instead of the UNIT * passed to the x11 `ws_init`.

There's a corresponding change to the top-level makefile which replaces x11.c with sim_ws.c, but it doesn't make sense for this repository.  There's also a change to ka10_dpy.c of course.