### PR TITLE
makefile: Fix case-sensitive path for cygwin 3 with Windows 10 WSL

### DIFF
--- a/makefile
+++ b/makefile
@@ -338,8 +338,8 @@ ifeq ($(WIN32),)  #*nix Environments (&& cygwin)
         else
           ifeq (cygwin,$(OSTYPE))
             # use 0readme_ethernet.txt documented Windows pcap build components
-            INCPATH += ../windows-build/winpcap/WpdPack/include
-            LIBPATH += ../windows-build/winpcap/WpdPack/lib
+            INCPATH += ../windows-build/winpcap/WpdPack/Include
+            LIBPATH += ../windows-build/winpcap/WpdPack/Lib
             PCAPLIB = wpcap
             LIBEXT = a
           else


### PR DESCRIPTION
Windows 10 1803 or later NTFS filenames are set to be case-sensitive if the Windows Subsystem for Linux (WSL) feature is turned-on. This was causing a build under cygwin 3.0.1 to fail detecting the libpcap header and library locations in the ../windows-build/winpcap directory.