### PR TITLE
3b2: Fix Coverity identified issues

### DIFF
--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -56,6 +56,9 @@ noret __libc_longjmp (jmp_buf buf, int val);
 #ifndef MIN
 #define MIN(x,y) ((x) < (y) ? (x) : (y))
 #endif
+#ifndef UNUSED
+#define UNUSED(x)  ((void)((x)))
+#endif
 
 /* -t flag: Translate a virtual address */
 #define EX_T_FLAG 1 << 19

--- a/scp.c
+++ b/scp.c
@@ -14527,6 +14527,23 @@ return cptr;
 }
 
 /*
+ * To avoid Coverity complaints about the use of rand() we define the function locally
+ */
+
+static uint32 sim_rand_seed;
+
+void sim_srand (unsigned int seed)
+{
+sim_rand_seed = (uint32)seed;
+}
+
+int sim_rand ()
+{
+sim_rand_seed = sim_rand_seed * 214013 + 2531011;
+return (sim_rand_seed >> 16) & RAND_MAX;
+}
+
+/*
  * Compiled in unit tests for the various device oriented library 
  * modules: sim_card, sim_disk, sim_tape, sim_ether, sim_tmxr, etc.
  */

--- a/scp.h
+++ b/scp.h
@@ -231,6 +231,12 @@ size_t sim_strlcpy (char *dst, const char *src, size_t size);
 #ifndef strcasecmp
 #define strcasecmp(str1, str2) sim_strcasecmp ((str1), (str2))
 #endif
+void sim_srand (unsigned int seed);
+int sim_rand (void);
+#ifdef RAND_MAX
+#undef RAND_MAX
+#endif
+#define RAND_MAX 32767
 CONST char *get_sim_opt (int32 opt, CONST char *cptr, t_stat *st);
 CONST char *get_sim_sw (CONST char *cptr);
 const char *put_switches (char *buf, size_t bufsize, uint32 sw);

--- a/sim_fio.c
+++ b/sim_fio.c
@@ -41,7 +41,7 @@
    sim_finit         -       initialize package
    sim_fopen         -       open file
    sim_fread         -       endian independent read (formerly fxread)
-   sim_write         -       endian independent write (formerly fxwrite)
+   sim_fwrite        -       endian independent write (formerly fxwrite)
    sim_fseek         -       conditionally extended (>32b) seek (
    sim_fseeko        -       extended seek (>32b if available)
    sim_fsize         -       get file size


### PR DESCRIPTION
This change also addresses some unused function parameter warnings issued by GNU Flycheck (not generally used by the build process, but useful when editing files with Flycheck enabled)