### PR TITLE
3b2: Soft-power shutdown via TIMER command

### DIFF
--- a/3B2/3b2_cpu.c
+++ b/3B2/3b2_cpu.c
@@ -3455,7 +3455,7 @@ static void cpu_calc_ints()
         cpu_int_ipl = cpu_int_vec = CPU_ID_IF_IPL;
     } else if ((csr_data & CSRUART) || (csr_data & CSRDMA)) {
         cpu_int_ipl = cpu_int_vec = CPU_IU_DMA_IPL;
-    } else if (csr_data & CSRCLK) {
+    } else if ((csr_data & CSRCLK) || (csr_data & CSRTIMO)) {
         cpu_int_ipl = cpu_int_vec = CPU_TMR_IPL;
     } else {
         cpu_int_ipl = cpu_int_vec = 0;

--- a/3B2/3b2_sysdev.h
+++ b/3B2/3b2_sysdev.h
@@ -69,6 +69,7 @@ void timer_write(uint32 pa, uint32 val, size_t size);
 t_stat timer0_svc(UNIT *uptr);
 t_stat timer1_svc(UNIT *uptr);
 t_stat timer2_svc(UNIT *uptr);
+t_stat timer_set_shutdown(UNIT *uptr, int32 val, CONST char *cptr, void *desc);
 
 /* CSR */
 t_stat csr_svc(UNIT *uptr);


### PR DESCRIPTION
This change enables the simulator to be shut down cleanly via a
soft-power shutdown command. This is implemented in the real 3B2/400
through the sanity timer, which, if it reaches zero, sets a bus timeout
flag in the CSR and issues an interrupt at IPL 15. The operating
system (System V UNIX) treats this as a shutdown request and enters
runlevel 0.

To use this change in a SIMH startup script, for example to implement a
3B2 simulator as a service, one could add these commands:

    # [... simulator setup ...]
    BOOT
    SET TIMER SHUTDOWN
    CONTINUE
    EXIT

On catching a SIGTERM, SIGINT, or SIGHUP, the simulator would return to
SCP control, set the soft power shutdown flag, and then continue
simulator execution. After the system is cleanly shut down, the
simulator would then exit back to the operating system.