### PR TITLE
3b2: Correct behavior for NI attach and detach

### DIFF
--- a/3B2/3b2_ni.h
+++ b/3B2/3b2_ni.h
@@ -121,6 +121,8 @@
 #define DBG_ERR   0x10
 #define DBG_ETH   0x20
 
+#define CHAR(c)   ((((c) >= 0x20) && ((c) < 0x7f)) ? (c) : '.')
+
 #define NI_CACHE_HAS_SPACE(i) (((ni.job_cache[(i)].wp + 1) % NI_CACHE_LEN) != ni.job_cache[(i)].rp)
 
 /*


### PR DESCRIPTION
Previously, the NI ethernet device expected to do all
autoconfiguration at attach time. Furthermore, if attaching failed for
some reason (e.g., permission issues on a tap device, etc.) the card
would be left autoconfigured, but in a broken state that could lead to
reading uninitialized memory.

This change fixes those bugs, and allows the device to be attached and
detached more freely. The card is now autoconfigured when it is
enabled.  Attaching and detaching are analogous to connecting or
disconnecting an ethernet transceiver from the physical device.