### PR TITLE
VAX8200: Added missing error bit to DWBUA CSR

### DIFF
--- a/VAX/vax820_ka.c
+++ b/VAX/vax820_ka.c
@@ -349,13 +349,11 @@ int32 pcsr_rd (int32 pa)
 int32 data;
 int32 ip_int = (ipir >> cur_cpu) & 0x1;
 data = ka_pcsr[cur_cpu] | (rxcd_int << PCSR_V_CONINT) | (ip_int << PCSR_V_IPINT);
-printf ("pcsr_rd: %08X\n", data);
 return data;
 }
 
 void pcsr_wr (int32 pa, int32 val, int32 lnt)
 {
-printf ("pcsr_wr: %08X\n", val);
 ka_pcsr[cur_cpu] &= ~(val & PCSR_W1C);
 ka_pcsr[cur_cpu] &= ~(PCSR_WR) | (val & PCSR_WR);
 if (val & PCSR_CONCLR)

--- a/VAX/vax820_uba.c
+++ b/VAX/vax820_uba.c
@@ -50,11 +50,13 @@
 #define UBACSR_BDP      0x01000000                      /* bad buffered datapath */
 #define UBACSR_EIE      0x00100000                      /* error interrupt en */
 #define UBACSR_UPI      0x00020000                      /* unibus power init */
-#define UBACSR_RD       0x00010000                      /* register dump */
-#define UBACSR_ONE      0x00008000                      /* must be one */
+#define UBACSR_DMP      0x00010000                      /* register dump */
+#define UBACSR_MBO      0x00008000                      /* must be one */
 #define UBACSR_IEN      0x000000FF                      /* internal error - NI */
 #define UBACSR_WR       (UBACSR_EIE)
 #define UBACSR_W1C      (UBACSR_BIF | UBACSR_TO | UBACSR_UIE | \
+                         UBACSR_IMR | UBACSR_BDP)
+#define UBACSR_ERRS     (UBACSR_BIF | UBACSR_TO | UBACSR_UIE | \
                          UBACSR_IMR | UBACSR_BDP)
 
 /* Vector offset register */
@@ -318,7 +320,9 @@ switch (ofs) {                                          /* case on offset */
         break;
 
     case UBACSR_OF:                                     /* CSR */
-        *val = uba_csr | UBACSR_ONE;
+        *val = uba_csr | UBACSR_MBO;
+        if (uba_csr & UBACSR_ERRS)                      /* any errors? */
+            *val |= UBACSR_ERR;                         /* yes, set logical OR bit */
         break;
 
     case UBAVO_OF:                                      /* VO */


### PR DESCRIPTION
As reported in #690

Also:
- Removed some debug messages that were left in from development.
- Renamed some macros to be more consistent with other simulators (xxx_RD would usually be a read mask)