### PR TITLE
Travis matrix build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ env:
   - SIM="uc15"
 sudo: required
 install: sh -ex .travis/deps.sh
-script: make $SIM
+script: make --jobs=4 $SIM

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,6 @@ os:
   - linux
   - osx
 language: c
-env:
-  # These are supposed to match ALL in makefile.
-  # Each job builds 10 simulators.
-  - SIM="pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp11"
-  - SIM="pdp15 vax microvax3900 microvax1 rtvax1000 microvax2 vax730 vax750 vax780 vax8200"
-  - SIM="vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 vaxstation3100m76 vaxstation4000m60"
-  - SIM="microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3"
-  - SIM="altair altairz80 gri i7094 ibm1130 id16 id32 sds lgp h316"
-  - SIM="cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 isys8010 isys8020 isys8030 isys8024"
-  - SIM="imds-225 scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma"
-  - SIM="uc15"
 sudo: required
 install: sh -ex .travis/deps.sh
-script: make --jobs=4 $SIM
+script: make --jobs=4 all

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ os:
   - linux
   - osx
 language: c
+env:
+  # These are supposed to match ALL in makefile.
+  # Each job builds 15 simulators.
+  - SIM="pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp11 pdp15 vax microvax3900 microvax1 rtvax1000"
+  - SIM="microvax2 vax730 vax750 vax780 vax8200 vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 vaxstation3100m76 vaxstation4000m60"
+  - SIM="microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3 altair altairz80 gri i7094 ibm1130"
+  - SIM="id16 id32 sds lgp h316 cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 isys8010 isys8020 isys8030 isys8024"
+  - SIM="imds-225 scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15"
 sudo: required
 install: sh -ex .travis/deps.sh
-script: make --jobs=4 all
+script: make $SIM

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,17 @@ os:
   - linux
   - osx
 language: c
+env:
+  # These are supposed to match ALL in makefile.
+  # Each job builds 10 simulators.
+  - SIM="pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp11"
+  - SIM="pdp15 vax microvax3900 microvax1 rtvax1000 microvax2 vax730 vax750 vax780 vax8200"
+  - SIM="vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 vaxstation3100m76 vaxstation4000m60"
+  - SIM="microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3"
+  - SIM="altair altairz80 gri i7094 ibm1130 id16 id32 sds lgp h316"
+  - SIM="cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 isys8010 isys8020 isys8030 isys8024"
+  - SIM="imds-225 scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma"
+  - SIM="uc15"
 sudo: required
 install: sh -ex .travis/deps.sh
-script: make all
+script: make $SIM

--- a/VAX/vax730_sys.c
+++ b/VAX/vax730_sys.c
@@ -1,3 +1,5 @@
+#error Word size too small.
+
 /* vax730_sys.c: VAX 11/730 system-specific logic
 
    Copyright (c) 2010-2011, Matt Burke


### PR DESCRIPTION
Split the monolithic Travis CI "make all" build into several jobs, one for each simulator.