### PR TITLE
3b2: Fix critical MAU issues

### DIFF
--- a/3B2/3b2_mau.h
+++ b/3B2/3b2_mau.h
@@ -283,13 +283,21 @@ typedef enum {
 } op_spec;
 
 /*
+ * 128-bit value
+ */
+typedef struct {
+    t_uint64 low;
+    t_uint64 high;
+} t_mau_128;
+
+/*
  * Not-a-Number Type
  */
 typedef struct {
     t_bool sign;
     t_uint64 high;
     t_uint64 low;
-} NAN_T;
+} T_NAN;
 
 /*
  * Extended Precision (80 bits).


### PR DESCRIPTION
- A bug in the Square Root implementation could lead to
  an infinite loop.

- Incorrect rounding was used when MAU destination register
  was single or double word.

- Fix Coverity-discovered issues.