### PR TITLE
3b2: STRCPY fix, CTC and NI cleanup

### DIFF
--- a/3B2/3b2_ctc.h
+++ b/3B2/3b2_ctc.h
@@ -139,6 +139,7 @@ struct pdinfo {
 
 typedef struct {
     uint32 time;        /* Time used during a tape session (in 25ms chunks) */
+    uint32 bytnum;      /* Byte number, for streaming mode */
 } CTC_STATE;
 
 extern DEVICE ctc_dev;

--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -134,7 +134,8 @@ noret __libc_longjmp (jmp_buf buf, int val);
 #define STOP_ESTK           6     /* Exception stack too deep */
 #define STOP_MMU            7     /* Unimplemented MMU Feature */
 #define STOP_POWER          8     /* System power-off */
-#define STOP_ERR            9     /* Other error */
+#define STOP_LOOP           9     /* Infinite loop stop */
+#define STOP_ERR           10     /* Other error */
 
 /* Exceptional conditions handled within the instruction loop */
 #define ABORT_EXC           1      /* CPU exception  */

--- a/3B2/3b2_ni.h
+++ b/3B2/3b2_ni.h
@@ -88,9 +88,6 @@
 #define NI_QPOLL_FAST          100
 #define NI_QPOLL_SLOW          50000
 
-#define NI_DIAG_CRC1           0x795268a4
-#define NI_DIAG_CRC2           0xfab1057c
-#define NI_DIAG_CRC3           0x10ca00cd
 #define NI_PUMP_CRC1           0xfab1057c
 #define NI_PUMP_CRC2           0xf6744bed
 

--- a/3B2/3b2_sys.c
+++ b/3B2/3b2_sys.c
@@ -82,6 +82,7 @@ const char *sim_stop_messages[] = {
     "Exception Stack Too Deep",
     "Unimplemented MMU Feature",
     "System Powered Off",
+    "Infinite Loop",
     "Simulator Error"
 };
 


### PR DESCRIPTION
- The previous fix for STRCPY introduced a new bug. STRCPY must always  copy the final NULL terminator of the string, but must NOT increment  the source or destination pointers for the NULL terminator.

- The CTC simulation did not correctly support streaming mode, which can in some cases request reads that are not on 512-byte block boundaries.

- To begin to support System V Release 4 UNIX, the NI card (called EMD under SVR4) needed to support several more CRC codes for pump code.