### PR TITLE
3b2: Add correct CTC subdevice information

### DIFF
--- a/3B2/3b2_ctc.c
+++ b/3B2/3b2_ctc.c
@@ -336,9 +336,10 @@ static void ctc_cmd(uint8 cid,
                   "[ctc_cmd] CTC_DSD (%d)\n",
                   rqe->opcode);
         delay = DELAY_DSD;
-        /* The system wants us to write sub-device structures at the
-         * supplied address, but we have nothing to write. */
-        pwrite_h(rqe->address, 0x0);
+        /* Write subdevice information to the host. */
+        pwrite_h(rqe->address, CTC_NUM_SD);
+        pwrite_h(rqe->address + 2, CTC_SD_FT25);
+        pwrite_h(rqe->address + 4, CTC_SD_FD5);
         cqe->opcode = CTC_SUCCESS;
         break;
     case CTC_FORMAT:

--- a/3B2/3b2_ctc.h
+++ b/3B2/3b2_ctc.h
@@ -84,6 +84,10 @@
 #define VTOC_PART       16          /* Number of "partitions" on tape */
 #define VTOC_VALID      0x600DDEEE  /* Magic number for valid VTOC */
 
+#define CTC_NUM_SD      2
+#define CTC_SD_FT25     4
+#define CTC_SD_FD5      1
+
 /* Physical Device Info (pdinfo) values */
 #define PD_VALID        0xCA5E600D  /* Magic number for valid PDINFO */
 #define PD_DRIVEID      5


### PR DESCRIPTION
The CTC (Cartridge Tape Drive) device has two subdevices, "FT25" and "FD5", which were not being set up correctly on initialization. This change fixes that behavior.