### PR TITLE
Fix Windows VD API name clash

### DIFF
--- a/sim_disk.c
+++ b/sim_disk.c
@@ -4154,10 +4154,10 @@ _rand_uuid_gen (uuidaddr);
 #endif
 
 static VHDHANDLE
-CreateVirtualDisk(const char *szVHDPath,
-                  uint32 SizeInSectors,
-                  uint32 BlockSize,
-                  t_bool bFixedVHD)
+ConstructVHD(const char *szVHDPath,
+             uint32 SizeInSectors,
+             uint32 BlockSize,
+             t_bool bFixedVHD)
 {
 VHD_Footer Footer;
 VHD_DynamicDiskHeader Dynamic;
@@ -4423,8 +4423,8 @@ return szHostPath;
 }
 
 static VHDHANDLE
-CreateDifferencingVirtualDisk(const char *szVHDPath,
-                              const char *szParentVHDPath)
+ConstructDifferencingVHD(const char *szVHDPath,
+                         const char *szParentVHDPath)
 {
 uint32 BytesPerSector = 512;
 VHDHANDLE hVHD = NULL;
@@ -4449,10 +4449,10 @@ if ((Status = GetVHDFooter (szParentVHDPath,
                             NULL,
                             0)))
     goto Cleanup_Return;
-hVHD = CreateVirtualDisk (szVHDPath,
-                          (uint32)(NtoHll(ParentFooter.CurrentSize)/BytesPerSector),
-                          NtoHl(ParentDynamic.BlockSize),
-                          FALSE);
+hVHD = ConstructVHD (szVHDPath,
+                     (uint32)(NtoHll(ParentFooter.CurrentSize)/BytesPerSector),
+                     NtoHl(ParentDynamic.BlockSize),
+                     FALSE);
 if (!hVHD) {
     Status = errno;
     goto Cleanup_Return;
@@ -4593,12 +4593,12 @@ return hVHD;
 
 static FILE *sim_vhd_disk_create (const char *szVHDPath, t_offset desiredsize)
 {
-return (FILE *)CreateVirtualDisk (szVHDPath, (uint32)(desiredsize/512), 0, (sim_switches & SWMASK ('X')));
+return (FILE *)ConstructVHD (szVHDPath, (uint32)(desiredsize/512), 0, (sim_switches & SWMASK ('X')));
 }
 
 static FILE *sim_vhd_disk_create_diff (const char *szVHDPath, const char *szParentVHDPath)
 {
-return (FILE *)CreateDifferencingVirtualDisk (szVHDPath, szParentVHDPath);
+return (FILE *)ConstructDifferencingVHD (szVHDPath, szParentVHDPath);
 }
 
 static t_stat


### PR DESCRIPTION
There's more than enough room for snarky and creative commends about virtual disks and the abbreviation "VD". :-)

Nonetheless, proposed name changes to allow MinGW-W64/MSYS2 compiles to move forward:

CreateVirtualDisk             -> ConstructVHD
CreateDifferencingVirtualDisk -> ConstructDifferencingVHD