### PR TITLE
MS CRT deprecation: Use "ISO names" vice POSIX.

### DIFF
--- a/AltairZ80/altairz80_sio.c
+++ b/AltairZ80/altairz80_sio.c
@@ -267,7 +267,7 @@ static void processDirEntry (const char *directory,
                              void *context) {
     if (filename != NULL) {
         NameNode_t *top = (NameNode_t *)malloc(sizeof(NameNode_t));
-        top -> name = strdup(filename);
+        top -> name = sim_strdup(filename);
         top -> next = nameListHead;
         nameListHead = top;
     }

--- a/Ibm1130/ibm1130_cpu.c
+++ b/Ibm1130/ibm1130_cpu.c
@@ -1436,7 +1436,7 @@ t_stat cpu_set_type (UNIT *uptr, int32 value, CONST char *cptr, void *desc)
     is_1800 = (value & UNIT_1800) != 0;                 /* set is_1800 mode flag */
 
     for (r = cpu_reg; r->name != NULL; r++) {           /* unhide or hide 1800-specific registers & state */
-        if (strnicmp(r->name, "XR", 2) == 0) {
+        if (sim_strnicmp(r->name, "XR", 2) == 0) {
             if (value & UNIT_1800)
                 CLRBIT(r->flags, REG_HIDDEN|REG_RO);
             else

--- a/Ibm1130/ibm1130_cr.c
+++ b/Ibm1130/ibm1130_cr.c
@@ -1321,7 +1321,7 @@ static t_bool nextdeck (void)
         if (*buf == '#' || *buf == '*' || *buf == ';')
             continue;                       /* comment */
 
-        if (strnicmp(buf, "!BREAK", 6) == 0) {  /* stop the simulation */
+        if (sim_strnicmp(buf, "!BREAK", 6) == 0) {  /* stop the simulation */
             break_simulation(STOP_DECK_BREAK);
             continue;
         }
@@ -1366,7 +1366,7 @@ static t_bool nextdeck (void)
 
             if (*tempfile == '\0') {                        /* first time, construct unique name */
                 strcpy(tempfile, "tempXXXXXX");             /* make a modifiable copy of the template */
-                if (mktemp(tempfile) == NULL) {
+                if (sim_mktemp(tempfile) == NULL) {
                     printf("Cannot create temporary card file name\n");
                     break_simulation(STOP_DECK_BREAK);
                     return 0;
@@ -1395,7 +1395,7 @@ static t_bool nextdeck (void)
                 fpos = ftell(deckfile);
                 if (fgets(buf, sizeof(buf), deckfile) == NULL)
                     break;                          /* oops, end of file */
-                if (buf[0] != '!' || strnicmp(buf, "!BREAK", 6) == 0)
+                if (buf[0] != '!' || sim_strnicmp(buf, "!BREAK", 6) == 0)
                     break;
                 alltrim(buf);
             }

--- a/Ibm1130/ibm1130_disk.c
+++ b/Ibm1130/ibm1130_disk.c
@@ -651,7 +651,7 @@ static t_stat phdebug_cmd (int32 flag, CONST char *ptr)
 {
     int val1, val2;
 
-    if (strcmpi(ptr, "off") == 0)
+    if (sim_strcmpi(ptr, "off") == 0)
         phdebug_lo = phdebug_hi = -1;
     else {
         switch(sscanf(ptr, "%x%x", &val1, &val2)) {

--- a/scp.c
+++ b/scp.c
@@ -6339,7 +6339,7 @@ if ((!cptr) || (*cptr == 0))
 gbuf[sizeof(gbuf)-1] = '\0';
 strlcpy (gbuf, cptr, sizeof(gbuf));
 sim_trim_endspc(gbuf);
-if (chdir(gbuf) != 0)
+if (sim_chdir(gbuf) != 0)
     return sim_messagef(SCPE_IOERR, "Unable to directory change to: %s\n", gbuf);
 return SCPE_OK;
 }
@@ -6519,7 +6519,7 @@ char FullPath[PATH_MAX + 1];
 
 sprintf (FullPath, "%s%s", directory, filename);
 
-if (!unlink (FullPath))
+if (!sim_unlink (FullPath))
     return;
 ctx->stat = sim_messagef (SCPE_ARG, "%s\n", strerror (errno));
 }
@@ -6640,9 +6640,9 @@ while ((c = strchr (c, '/'))) {
         }
     if (
 #if defined(_WIN32)
-        mkdir (path)
+        sim_mkdir (path)
 #else
-        mkdir (path, 0777)
+        sim_mkdir (path, 0777)
 #endif
                           )
         return sim_messagef (SCPE_ARG, "Can't create directory: %s - %s\n", path, strerror (errno));
@@ -6651,9 +6651,9 @@ while ((c = strchr (c, '/'))) {
     }
 if (
 #if defined(_WIN32)
-    mkdir (path)
+    sim_mkdir (path)
 #else
-    mkdir (path, 0777)
+    sim_mkdir (path, 0777)
 #endif
                       )
     return sim_messagef (SCPE_ARG, "Can't create directory: %s - %s\n", path, strerror (errno));
@@ -6665,7 +6665,7 @@ t_stat rmdir_cmd (int32 flg, CONST char *cptr)
 GET_SWITCHES (cptr);                                    /* get switches */
 if ((!cptr) || (*cptr == '\0'))
     return sim_messagef (SCPE_2FARG, "Must specify a directory\n");
-if (rmdir (cptr))
+if (sim_rmdir (cptr))
     return sim_messagef (SCPE_ARG, "Can't remove directory: %s - %s\n", cptr, strerror (errno));
 return SCPE_OK;
 }
@@ -7571,7 +7571,7 @@ sim_switches &= ~(SWMASK ('F') | SWMASK ('D') | SWMASK ('Q'));  /* remove digest
     goto Cleanup_Return;                                                \
     }
 
-if (fstat (fileno (rfile), &rstat)) {
+if (fstat (sim_fileno (rfile), &rstat)) {
     r = SCPE_IOERR;
     goto Cleanup_Return;
     }

--- a/sim_console.c
+++ b/sim_console.c
@@ -1665,7 +1665,7 @@ for (i=(was_active_command ? sim_rem_cmd_active_line : 0);
             int32 save_quiet = sim_quiet;
 
             sim_quiet = 1;
-            sprintf (sim_rem_con_temp_name, "sim_remote_console_%d.temporary_log", (int)getpid());
+            sprintf (sim_rem_con_temp_name, "sim_remote_console_%d.temporary_log", (int)sim_getpid());
             sim_set_logon (0, sim_rem_con_temp_name);
             sim_quiet = save_quiet;
             sim_log_temp = TRUE;

--- a/sim_defs.h
+++ b/sim_defs.h
@@ -124,6 +124,7 @@ extern int sim_vax_snprintf(char *buf, size_t buf_size, const char *fmt, ...);
 #include <errno.h>
 #include <limits.h>
 #include <ctype.h>
+#include "sim_iso_names.h"
 
 #ifndef EXIT_FAILURE
 #define EXIT_FAILURE 1

--- a/sim_disk.c
+++ b/sim_disk.c
@@ -3600,7 +3600,7 @@ if (!File) {
     goto Return_Cleanup;
     }
 if (ModifiedTimeStamp) {
-    if (fstat (fileno (File), &statb)) {
+    if (fstat (sim_fileno (File), &statb)) {
         Return = errno;
         goto Return_Cleanup;
         }

--- a/sim_ether.c
+++ b/sim_ether.c
@@ -417,7 +417,7 @@ t_stat eth_mac_scan_ex (ETH_MAC* mac, const char* strmac, UNIT *uptr)
   memset (&state, 0, sizeof(state));
   _eth_get_system_id (state.system_id, sizeof(state.system_id));
   strlcpy (state.sim, sim_name, sizeof(state.sim));
-  if (getcwd (state.cwd, sizeof(state.cwd))) {};
+  if (sim_getcwd (state.cwd, sizeof(state.cwd))) {};
   if (uptr)
     strlcpy (state.uname, sim_uname (uptr), sizeof(state.uname));
   cptr = strchr (strmac, '>');

--- a/sim_fio.c
+++ b/sim_fio.c
@@ -709,9 +709,13 @@ return 0;
 char *sim_getcwd (char *buf, size_t buf_size)
 {
 #if defined (VMS)
-return getcwd (buf, buf_size, 0);
+return sim_getcwd (buf, buf_size, 0);
+#elif defined(USE_ISO_NAMES)
+ /* Can't use a #define to rename because the rename is the same as the
+    function name. */
+ return _getcwd(buf, buf_size);
 #else
-return getcwd (buf, buf_size);
+ return getcwd (buf, buf_size);
 #endif
 }
 

--- a/sim_iso_names.h
+++ b/sim_iso_names.h
@@ -1,0 +1,43 @@
+/* sim_iso_names.h
+ *
+ * Provide renames for deprecated POSIX function names, providing a shim if/when other platforms need similar functionality.
+ * This seems to only affect MSVC/Win32/Win64 platforms.
+ * .
+ *
+ * Author: B. Scott Michel
+ * "scooter me fecit"
+ */
+#if !defined(SIM_ISO_NAMES_H)
+
+#if !defined(USE_ISO_NAMES)
+#if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN7)) || (defined(_MSC_VER) && (_MSC_VER >= 1900))
+#define USE_ISO_NAMES
+#endif
+#endif /* USE_ISO_NAMES */
+
+#if defined(USE_ISO_NAMES)
+#define sim_chdir _chdir
+#define sim_fileno _fileno
+#define sim_getpid _getpid
+#define sim_mkdir _mkdir
+#define sim_mktemp _mktemp
+#define sim_rmdir _rmdir
+#define sim_strcmpi _stricmp
+#define sim_strdup _strdup
+#define sim_strnicmp _strnicmp
+#define sim_unlink _unlink
+#else
+#define sim_chdir chdir
+#define sim_fileno fileno
+#define sim_getpid getpid
+#define sim_mkdir mkdir
+#define sim_mktemp mktemp
+#define sim_rmdir rmdir
+#define sim_strcmpi strcmpi
+#define sim_strdup strdup
+#define sim_strnicmp strnicmp
+#define sim_unlink unlink
+#endif
+
+#define SIM_ISO_NAMES_H
+#endif /* SIM_ISO_NAMES_H */

--- a/sim_tape.c
+++ b/sim_tape.c
@@ -4433,7 +4433,7 @@ if (f == NULL) {
     return errno;
     }
 memset (&statb, 0, sizeof (statb));
-if (fstat (fileno (f), &statb)) {
+if (fstat (sim_fileno (f), &statb)) {
     sim_printf ("Can't stat: %s\n", filename);
     fclose (f);
     return -1;


### PR DESCRIPTION
sim_iso_names.h provides the shim to rename functions that the MS CRT
considers "deprecated".  Added to future-proof the simh code base when
MS eventually decides to fully remove them from the CRT.

Can remove _CRT_NONSTDC_NO_WARNINGS from MSVC build.

(Close the pull request if not interested.)