### PR TITLE
PDP8: Fix prematurely stopped diag test

### DIFF
--- a/PDP8/tests/pdp8_test.ini
+++ b/PDP8/tests/pdp8_test.ini
@@ -14,11 +14,20 @@ set cpu 32k
 set cpu eae
 
 :: AND, TAD, Operate and basic MQ instruction test (D0AB)
+:: This test halts after the first 3 instructions to let the
+:: operator verify that HLT and CLA works before continuing 
+:: onto the real tests.
 echof -n "** PDP-8: Basic Instruction Test (1): "
 load diags/maindec-8e-d0ab-pb.bin
+:: Patch address 5276 with HLT to stop execution after a 
+:: full pass is done or else it will send BEL every 1440
+:: iterations.
+dep 5276 7402
 dep sr 07777
 go -q 200
 if (PC != 0147 || AC != 0) echof "MAINDEC-8/E-D0AB failed."; exit 1
+go -q
+if (PC != 05277) echof "MAINDEC-8/E-D0AB failed."; exit 1
 echof "passed"
 
 :: Autoindexing, Indirect addressing, and the DCA instruction with


### PR DESCRIPTION
The D0AB (PDP-8: Basic Instruction Test 1) stops after just three instructions to let the operator verify that the CLA and HLT instructions works properly. After that the operator is expected to press the CONT switch to continue to the rest of the tests in the diag.

