### PR TITLE
B5500: Avoid potential truncataion warning with type consistency

### DIFF
--- a/B5500/b5500_defs.h
+++ b/B5500/b5500_defs.h
@@ -72,7 +72,7 @@ typedef struct _opcode
 }
 t_opcode;
 
-void print_opcode(FILE * ofile, t_value val, int chr_mode);
+void print_opcode(FILE * ofile, uint16 val, int chr_mode);
 
 t_stat chan_reset(DEVICE *);
 t_stat chan_boot(t_uint64);

--- a/B5500/b5500_sys.c
+++ b/B5500/b5500_sys.c
@@ -341,7 +341,7 @@ t_opcode  char_ops[] = {
 
 /* Print out an instruction */
 void
-print_opcode(FILE * of, t_value val, int chr_mode)
+print_opcode(FILE * of, uint16 val, int chr_mode)
 {
     uint16      op;
     t_opcode   *tab = (chr_mode) ? char_ops: word_ops;
@@ -410,14 +410,14 @@ fprint_sym(FILE * of, t_addr addr, t_value * val, UNIT * uptr, int32 sw)
     if (sw & SWMASK('W')) {     /* Word mode opcodes */
         fputs("   ", of);
         for (i = 36; i >= 0; i-=12) {
-                int     op = (int)(inst >> i) & 07777;
+                uint16  op = (uint16)(inst >> i) & 07777;
                 print_opcode(of, op, 0);
         }
     }
     if (sw & SWMASK('C')) {     /* Char mode opcodes */
         fputs("   ", of);
         for (i = 36; i >= 0; i-=12) {
-                int     op = (int)(inst >> i) & 07777;
+                uint16  op = (uint16)(inst >> i) & 07777;
                 print_opcode(of, op, 1);
         }
     }


### PR DESCRIPTION
Some compilers correctly generate this warning:

simh-markpizz\B5500\b5500_sys.c(349,13): warning C4244: '=': conversion from 't_value' to 'uint
16', possible loss of data [C:\Users\Mark\Documents\simh-markpizz\BIN\cmake-vs2019\b5500.vcxproj]

This is one way to fix this.  A direct cast would be fewer changes, but all the input data is already uint16 or even 12 bits, so this seemed appropriate.

OK to merge.

BTW, there was a minor change to sim_card.c recently which you should migrate back to your repo...