### PR TITLE
display: Add display_close.

### DIFF
--- a/display/display.c
+++ b/display/display.c
@@ -975,6 +975,18 @@ display_init(enum display_type type, int sf, void *dptr)
     fprintf(stderr, "Display initialization failed\r\n");
     return 0;
 }
+
+void
+display_close(void *dptr)
+{
+    if (!initialized)
+        return;
+
+    free (points);
+    ws_shutdown();
+
+    initialized = 0;
+}
 
 void
 display_reset(void)

--- a/display/display.h
+++ b/display/display.h
@@ -65,6 +65,11 @@ enum display_type {
  */
 extern int display_init(enum display_type, int scale, void *dptr);
 
+/*
+ * close display
+ */
+extern void display_close(void *dptr);
+
 /* return size of virtual display */
 extern int display_xpoints(void);
 extern int display_ypoints(void);


### PR DESCRIPTION
As per request.

Adds to display.h:

```
extern void display_close(void *dptr); 
```

Used to close a display and associated resources.  Should be called from SIMH device reset routines when DEV_DIS is off.