### PR TITLE
Display/video fixes.

### DIFF
--- a/display/display.c
+++ b/display/display.c
@@ -359,6 +359,7 @@ static long queue_interval;
 #define Y(P) (((P) - points) / xpixels)
 
 static int initialized = 0;
+static void *device = NULL;  /* Current display device. */
 
 /*
  * global set by O/S display level to indicate "light pen tip switch activated"
@@ -969,6 +970,7 @@ display_init(enum display_type type, int sf, void *dptr)
 
     initialized = 1;
     init_failed = 0;            /* hey, we made it! */
+    device = dptr;
     return 1;
 
  failed:
@@ -982,10 +984,14 @@ display_close(void *dptr)
     if (!initialized)
         return;
 
+    if (device != dptr)
+        return;
+
     free (points);
     ws_shutdown();
 
     initialized = 0;
+    device = NULL;
 }
 
 void

--- a/sim_video.c
+++ b/sim_video.c
@@ -564,19 +564,24 @@ static t_stat vid_init_controllers (void)
     vid_gamepad_ok = (ver.major > 2 ||
                       (ver.major == 2 && (ver.minor > 0 || ver.patch >= 4)));
 
-    SDL_InitSubSystem(SDL_INIT_JOYSTICK);
     if (vid_gamepad_ok)
         SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER);
+    else
+        SDL_InitSubSystem(SDL_INIT_JOYSTICK);
 
     if (SDL_JoystickEventState (SDL_ENABLE) < 0) {
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        if (vid_gamepad_ok)
+            SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        else
+            SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
         return SCPE_IOERR;
         }
 
     if (vid_gamepad_ok && SDL_GameControllerEventState (SDL_ENABLE) < 0) {
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        if (vid_gamepad_ok)
+            SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+        else
+            SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
         return SCPE_IOERR;
         }
 
@@ -661,8 +666,10 @@ if (vid_active) {
     vid_gamepad_inited = 0;
     memset (motion_callback, 0, sizeof motion_callback);
     memset (button_callback, 0, sizeof button_callback);
-    SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
-    SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+    if (vid_gamepad_ok)
+        SDL_QuitSubSystem(SDL_INIT_GAMECONTROLLER);
+    else
+        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
 
     vid_active = FALSE;
     if (vid_ready) {


### PR DESCRIPTION
If there is more than one display device and they call display_close from their reset routines, they will conflict.  This adds a check that only the device that opened the display is allowed to close it.

The other commit is a cleanup as per SDL documentation.  Maybe it's harmless to initialize and quit both subsystems, but I'd rather err on the side of cautiousness here.