### PR TITLE
APPVEYOR: Save built artifacts in a zip file.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ before_build:
   "\"C:\\Program Files (x86)\\Microsoft Visual Studio 9.0\\VC\\vcvarsall.bat\""
 build_script:
   cmd: cd "Visual Studio Projects" & vcbuild /M%NUMBER_OF_PROCESSORS% /useenv /rebuild Simh.sln "Release|Win32"
+artifacts:
+  - path: BIN
 notifications:
   - provider: Email
     to:


### PR DESCRIPTION
I'm not sure if this will work, but according to https://www.appveyor.com/docs/packaging-artifacts/, this should put the entire BIN directory in a zip file on the Appveyor web site.

The pull request is in a draft state until I can verify it works.  Also, is it a good thing to do?