### PR TITLE
IMLAC: Fix two minor bugs.

### DIFF
--- a/imlac/imlac_dp.c
+++ b/imlac/imlac_dp.c
@@ -148,8 +148,8 @@ dp_iot (uint16 insn, uint16 AC)
     DPC = 0;
   }
   if ((insn & 0772) == 0002) { /* DLA */
-    sim_debug (DBG, &dp_dev, "DPC set to %06o\n", AC);
-    DPC |= AC;
+    sim_debug (DBG, &dp_dev, "DPC set to %06o\n", AC & memmask);
+    DPC |= AC & memmask;
   }
   if ((insn & 0771) == 0011) { /* CTB */
     ;

--- a/imlac/imlac_tty.c
+++ b/imlac/imlac_tty.c
@@ -124,7 +124,7 @@ tty_r_svc(UNIT *uptr)
     return SCPE_OK;
 
   if (uptr->fileref != NULL) {
-    char buf;
+    unsigned char buf;
     if (sim_fread (&buf, 1, 1, uptr->fileref) == 1) {
       sim_debug (DBG, &tty_dev, "Received character %03o\n", buf);
       RBUF = buf;


### PR DESCRIPTION
- Display PC masked to be inside core memory.
- Do not sign extend characters read from TTY.