### PR TITLE
IMLAC: Fullscreen mode.

### DIFF
--- a/imlac/imlac_kbd.c
+++ b/imlac/imlac_kbd.c
@@ -226,6 +226,9 @@ kbd_both (uint32 key)
   case SIM_KEY_DELETE:
     code = 0177;
     break;
+  case SIM_KEY_F11:
+    vid_set_fullscreen (!vid_is_fullscreen ());
+    break;
   default:
     return 0;
   }

--- a/sim_video.c
+++ b/sim_video.c
@@ -1404,6 +1404,20 @@ if (SDL_SemWait (vid_mouse_events.sem) == 0) {
     }
 }
 
+t_bool vid_is_fullscreen (void)
+{
+    return SDL_GetWindowFlags (vid_window) & SDL_WINDOW_FULLSCREEN_DESKTOP;
+}
+
+t_stat vid_set_fullscreen (t_bool flag)
+{
+if (flag)
+    SDL_SetWindowFullscreen (vid_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
+else
+    SDL_SetWindowFullscreen (vid_window, 0);
+return SCPE_OK;
+}
+
 void vid_update (void)
 {
 SDL_Rect vid_dst;
@@ -2367,5 +2381,17 @@ t_stat vid_screenshot (const char *filename)
 {
 sim_printf ("video support unavailable\n");
 return SCPE_NOFNC|SCPE_NOMESSAGE;
+}
+
+t_bool vid_is_fullscreen (void)
+{
+sim_printf ("video support unavailable\n");
+return FALSE;
+}
+
+t_stat vid_set_fullscreen (t_bool flag)
+{
+sim_printf ("video support unavailable\n");
+return SCPE_OK;
 }
 #endif /* defined(USE_SIM_VIDEO) */

--- a/sim_video.c
+++ b/sim_video.c
@@ -1418,21 +1418,38 @@ else
 return SCPE_OK;
 }
 
+static void vid_stretch(SDL_Rect *r)
+{
+/* Return in r a rectangle with the same aspect ratio as the video
+   buffer but scaled to fit precisely in the output window.  Normally,
+   the buffer and the window have the same sizes, but if the window is
+   resized, or fullscreen is in effect, they are not. */
+int w, h;
+SDL_GetRendererOutputSize(vid_renderer, &w, &h);
+if ((double)h / vid_height < (double)w / vid_width) {
+    r->w = vid_width * h / vid_height;
+    r->h = h;
+    r->x = (w - r->w) / 2;
+    r->y = 0;
+    }
+else {
+    r->w = w;
+    r->h = vid_height * w / vid_width;
+    r->x = 0;
+    r->y = (h - r->h) / 2;
+    }
+}
+
 void vid_update (void)
 {
 SDL_Rect vid_dst;
-
-vid_dst.x = 0;
-vid_dst.y = 0;
-vid_dst.w = vid_width;
-vid_dst.h = vid_height;
-
+vid_stretch(&vid_dst);
 sim_debug (SIM_VID_DBG_VIDEO, vid_dev, "Video Update Event: \n");
 if (sim_deb)
     fflush (sim_deb);
 if (SDL_RenderClear (vid_renderer))
     sim_printf ("%s: Video Update Event: SDL_RenderClear error: %s\n", vid_dname(vid_dev), SDL_GetError());
-if (SDL_RenderCopy (vid_renderer, vid_texture, NULL, NULL))
+if (SDL_RenderCopy (vid_renderer, vid_texture, NULL, &vid_dst))
     sim_printf ("%s: Video Update Event: SDL_RenderCopy error: %s\n", vid_dname(vid_dev), SDL_GetError());
 SDL_RenderPresent (vid_renderer);
 }

--- a/sim_video.h
+++ b/sim_video.h
@@ -198,6 +198,8 @@ t_stat vid_show_release_key (FILE* st, UNIT* uptr, int32 val, CONST void* desc);
 t_stat vid_show_video (FILE* st, UNIT* uptr, int32 val, CONST void* desc);
 t_stat vid_show (FILE* st, DEVICE *dptr,  UNIT* uptr, int32 val, CONST char* desc);
 t_stat vid_screenshot (const char *filename);
+t_bool vid_is_fullscreen (void);
+t_stat vid_set_fullscreen (t_bool flag);
 
 extern t_bool vid_active;
 void vid_set_cursor_position (int32 x, int32 y);        /* cursor position (set by calling code) */


### PR DESCRIPTION
This adds sim_video APIs for querying and setting fullscreen mode.  And then uses these APIs from the Imlac simulator.

When in fullscreen mode, the frame buffer is scaled to the size of the display and positioned in the center.