### PR TITLE
AltairZ80: Fix SS1 device to return correct 2-digit year.

### DIFF
--- a/AltairZ80/s100_ss1.c
+++ b/AltairZ80/s100_ss1.c
@@ -386,10 +386,10 @@ static uint8 SS1_Read(const uint32 Addr)
                 cData = (toBCD(currentTime.tm_mon+1) >> 4) & 0xF;
                 break;
             case 11:
-                cData = toBCD(currentTime.tm_year-22) & 0xF;
+                cData = toBCD(currentTime.tm_year % 100) & 0xF;
                 break;
             case 12:
-                cData = (toBCD(currentTime.tm_year-22) >> 4) & 0xF;
+                cData = (toBCD(currentTime.tm_year % 100) >> 4) & 0xF;
                 break;
             default:
                 cData = 0;


### PR DESCRIPTION
The SS1 device was returning (tm.tm_year-22) for the 2 digit year
causing the current year to be returned as '98' (120-22=98). This
PR changes the year calculation to (tm.tm_year%100).