### PR TITLE
SCP: Adds VM-specific stopped message handler

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -451,6 +451,7 @@ void (*sim_vm_fprint_addr) (FILE *st, DEVICE *dptr, t_addr addr) = NULL;
 t_addr (*sim_vm_parse_addr) (DEVICE *dptr, CONST char *cptr, CONST char **tptr) = NULL;
 t_value (*sim_vm_pc_value) (void) = NULL;
 t_bool (*sim_vm_is_subroutine_call) (t_addr **ret_addrs) = NULL;
+t_bool (*sim_vm_fprint_stopped_gen) (FILE *st, t_stat v, REG *pc, DEVICE *dptr) = NULL;
 t_bool (*sim_vm_fprint_stopped) (FILE *st, t_stat reason) = NULL;
 const char *sim_vm_release = NULL;
 const char *sim_vm_release_message = NULL;
@@ -8909,6 +8910,10 @@ int32 i;
 t_stat r = 0;
 t_addr k;
 t_value pcval;
+
+if ((sim_vm_fprint_stopped_gen != NULL) &&              /* if a VM-specific handler is defined */
+    (!sim_vm_fprint_stopped_gen (st, v, pc, dptr)))     /*   call it; if it returned FALSE, */
+    return;                                             /*     we're done */
 
 fputc ('\n', st);                                       /* start on a new line */
 

--- a/scp.h
+++ b/scp.h
@@ -445,6 +445,7 @@ extern CTAB *sim_vm_cmd;
 extern void (*sim_vm_sprint_addr) (char *buf, DEVICE *dptr, t_addr addr);
 extern void (*sim_vm_fprint_addr) (FILE *st, DEVICE *dptr, t_addr addr);
 extern t_addr (*sim_vm_parse_addr) (DEVICE *dptr, CONST char *cptr, CONST char **tptr);
+extern t_bool (*sim_vm_fprint_stopped_gen) (FILE *st, t_stat v, REG *pc, DEVICE *dptr);
 extern t_bool (*sim_vm_fprint_stopped) (FILE *st, t_stat reason);
 extern t_value (*sim_vm_pc_value) (void);
 extern t_bool (*sim_vm_is_subroutine_call) (t_addr **ret_addrs);


### PR DESCRIPTION
Adds the ability for a VM to define its own stopped message for all
codes, including SCPE errors. For example, on the AltairZ80 simulator,
a custom stop message handler could also display CPU flags and registers:

Simulation stopped C0Z0M0E0I0 A=61 B=1108 D=B818 H=D398 S=BC33 P=CC71 IN 0Ah
sim> s

Step expired C0Z0M0E0I0 A=11 B=1108 D=B818 H=D398 S=BC33 P=CC73 MOV M,A

sim_vm_fprint_stopped_gen = &my_vm_stopped_gen;

t_bool my_vm_stopped_gen (FILE *st, t_stat v, REG *pc, DEVICE *dptr) {
    /* display stopped message */
    fprintf(st, "My VM stopped!");

    return TRUE;  /* display SCP stopped message */

    return FALSE; /* do not display SCP stopped message */
}