### PR TITLE
VIDEO, IMLAC: Add new sim_video stubs.  Use them in Imlac simulator.

### DIFF
--- a/imlac/imlac_bel.c
+++ b/imlac/imlac_bel.c
@@ -58,9 +58,7 @@ bel_iot (uint16 insn, uint16 AC)
   sim_debug (DBG, &bel_dev, "IOT\n");
   if ((insn & 0771) == 0711) { /* BEL */
     sim_debug (DBG, &bel_dev, "Dong!\n");
-#ifdef HAVE_LIBSDL
     vid_beep ();
-#endif
   }
   return AC;
 }

--- a/imlac/imlac_cpu.c
+++ b/imlac/imlac_cpu.c
@@ -25,9 +25,7 @@
 */
 
 #include "imlac_defs.h"
-#ifdef HAVE_LIBSDL
 #include "display/display.h"
-#endif
 
 
 /* Debug */
@@ -668,7 +666,6 @@ rom_show_type (FILE *st, UNIT *up, int32 v, CONST void *dp)
   return SCPE_OK;
 }
 
-#ifdef HAVE_LIBSDL
 /* Called from display library to get data switches. */
 void
 cpu_get_switches (unsigned long *p1, unsigned long *p2)
@@ -683,4 +680,3 @@ cpu_set_switches (unsigned long p1, unsigned long p2)
 {
   DS = p1 & 0177777;
 }
-#endif /* HAVE_LIBSDL */

--- a/imlac/imlac_crt.c
+++ b/imlac/imlac_crt.c
@@ -47,12 +47,18 @@ static DEBTAB crt_deb[] = {
   { NULL, 0 }
 };
 
+#if defined(USE_SIM_VIDEO) && defined(HAVE_LIBSDL)
+#define CRT_DIS  0
+#else
+#define CRT_DIS  DEV_DIS
+#endif
+
 DEVICE crt_dev = {
   "CRT", &crt_unit, NULL, NULL,
   1, 8, 16, 1, 8, 16,
   NULL, NULL, &crt_reset,
   NULL, NULL, NULL,
-  NULL, DEV_DISABLE | DEV_DEBUG | DEV_DIS, 0, crt_deb,
+  NULL, DEV_DISABLE | DEV_DEBUG | CRT_DIS, 0, crt_deb,
   NULL, NULL, NULL, NULL, NULL, NULL
 };
 

--- a/sim_video.c
+++ b/sim_video.c
@@ -2616,4 +2616,57 @@ sim_printf ("video support unavailable\n");
 return SCPE_OK;
 }
 
+t_stat vid_open_window (VID_DISPLAY **vptr, DEVICE *dptr, const char *title, uint32 width, uint32 height, int flags)
+{
+*vptr = NULL;
+return SCPE_NOFNC;
+}
+
+t_stat vid_close_window (VID_DISPLAY *vptr)
+{
+return SCPE_OK;
+}
+
+uint32 vid_map_rgb_window (VID_DISPLAY *vptr, uint8 r, uint8 g, uint8 b)
+{
+return 0;
+}
+
+void vid_draw_window (VID_DISPLAY *vptr, int32 x, int32 y, int32 w, int32 h, uint32 *buf)
+{
+return;
+}
+
+void vid_refresh_window (VID_DISPLAY *vptr)
+{
+return;
+}
+
+t_stat vid_set_cursor_window (VID_DISPLAY *vptr, t_bool visible, uint32 width, uint32 height, uint8 *data, uint8 *mask, uint32 hot_x, uint32 hot_y)
+{
+return SCPE_NOFNC;
+}
+
+t_bool vid_is_fullscreen_window (VID_DISPLAY *vptr)
+{
+sim_printf ("video support unavailable\n");
+return FALSE;
+}
+
+t_stat vid_set_fullscreen_window (VID_DISPLAY *vptr, t_bool flag)
+{
+sim_printf ("video support unavailable\n");
+return SCPE_OK;
+}
+
+void vid_set_cursor_position_window (VID_DISPLAY *vptr, int32 x, int32 y)
+{
+return;
+}
+
+const char *vid_key_name (int32 key)
+{
+return "";
+}
+
 #endif /* defined(USE_SIM_VIDEO) */

--- a/sim_video.h
+++ b/sim_video.h
@@ -217,7 +217,6 @@ uint32 vid_map_rgb_window (VID_DISPLAY *vptr, uint8 r, uint8 g, uint8 b);
 void vid_draw_window (VID_DISPLAY *vptr, int32 x, int32 y, int32 w, int32 h, uint32 *buf);
 void vid_refresh_window (VID_DISPLAY *vptr);
 t_stat vid_set_cursor_window (VID_DISPLAY *vptr, t_bool visible, uint32 width, uint32 height, uint8 *data, uint8 *mask, uint32 hot_x, uint32 hot_y);
-t_stat vid_show_video_window (VID_DISPLAY *vptr, FILE* st, UNIT* uptr, int32 val, CONST void* desc);
 t_bool vid_is_fullscreen_window (VID_DISPLAY *vptr);
 t_stat vid_set_fullscreen_window (VID_DISPLAY *vptr, t_bool flag);
 void vid_set_cursor_position_window (VID_DISPLAY *vptr, int32 x, int32 y);        /* cursor position (set by calling code) */


### PR DESCRIPTION
As per https://github.com/simh/simh/pull/965#issuecomment-733172291.

This cleans up *some* uses of #ifdef HAVE_LIBSDL in the Imlac simulator.  The sim_video component offers stubs when SDL isn't available, but the display library doesn't and isn''t even linked in by the makefile.