### PR TITLE
I650, IBM1130, PDP11, PDP18b, VAX, Sigma, CARD: Fix set but unused variables.

### DIFF
--- a/I650/i650_dsk.c
+++ b/I650/i650_dsk.c
@@ -453,8 +453,6 @@ t_stat dsk_reset(DEVICE * dptr)
 
 t_stat dsk_attach(UNIT * uptr, CONST char *file)
 {
-    DEVICE             *dptr = find_dev_from_unit(uptr);
-    int                 unit = (uptr - dptr->units);
     t_stat              r;
     int                    flen;
 

--- a/Ibm1130/ibm1130_t2741.c
+++ b/Ibm1130/ibm1130_t2741.c
@@ -5,12 +5,8 @@
 
 #include "ibm1130_defs.h"
 #include "sim_sock.h"
-#include "sim_tmxr.h"
 
 #define DEBUG_T2741
-
-static TMLN t2741_ldsc = { 0 };                         /* line descr for telnet attachment */
-static TMXR t2741_tmxr = { 1, 0, 0, &t2741_ldsc };      /* line mux for telnet attachment */
 
 #define T2741_DSW_TRANSMIT_NOT_READY            0x4000
 #define T2741_DSW_READ_RESPONSE                 0x1000

--- a/PDP11/pdp11_rq.c
+++ b/PDP11/pdp11_rq.c
@@ -3015,7 +3015,10 @@ if (cp->ctype == DEFAULT_CTYPE)
     cp->ctype = (UNIBUS? UDA50_CTYPE : RQDX3_CTYPE);
 
 if (!plugs_inited ) {
-    uint32 d, u = 0;
+#if !defined (VM_VAX)
+    uint32 u = 0;
+#endif
+    uint32 d;
     char uname[16];
 
     plugs_inited  = TRUE;

--- a/PDP18B/pdp18b_dt.c
+++ b/PDP18B/pdp18b_dt.c
@@ -221,6 +221,12 @@
                         else CLR_INT (DTA);
 
 #else                                                   /* Type 550 */
+
+static const int32 map_unit[16] = {                     /* Type 550 unit map */
+    -1, 1,  2,  3,  4,  5,  6,  7,
+    0, -1, -1, -1, -1, -1, -1, -1
+    };
+
 #define DTA_V_UNIT      12                              /* unit select */
 #define DTA_M_UNIT      017
 #define DTA_UNIT        (DTA_M_UNIT << DTA_V_UNIT)
@@ -344,10 +350,6 @@ int32 dt_dctime = 40000;                                /* decel time */
 int32 dt_substate = 0;
 int32 dt_logblk = 0;
 int32 dt_stopoffr = 0;                                  /* stop on off reel */
-static const int32 map_unit[16] = {                     /* Type 550 unit map */
-    -1, 1,  2,  3,  4,  5,  6,  7,
-    0, -1, -1, -1, -1, -1, -1, -1
-    };
 
 int32 dt75 (int32 dev, int32 pulse, int32 dat);
 int32 dt76 (int32 dev, int32 pulse, int32 dat);

--- a/VAX/vax750_stddev.c
+++ b/VAX/vax750_stddev.c
@@ -83,40 +83,6 @@
 #define TXDB_SEL        (TXDB_M_SEL << TXDB_V_SEL)      /* non-terminal */
 #define TXDB_GETSEL(x)  (((x) >> TXDB_V_SEL) & TXDB_M_SEL)
 
-static BITFIELD rx_csr_bits[] = {
-    BITNCF(6),                          /* unused */
-    BIT(IE),                            /* Interrupt Enable */
-    BIT(DONE),                          /* Xmit Ready */
-    BITNCF(8),                          /* unused */
-    ENDBITS
-};
-
-static BITFIELD rx_buf_bits[] = {
-    BITF(DAT,8),                        /* data buffer */
-    BITNCF(5),                          /* unused */
-    BIT(RBRK),
-    BIT(OVR),
-    BIT(ERR),
-    ENDBITS
-};
-
-static BITFIELD tx_csr_bits[] = {
-    BIT(XBR),                           /* Break */
-    BITNC,                              /* unused */
-    BIT(MAINT),                         /* Maint */
-    BITNCF(3),                          /* unused */
-    BIT(IE),                            /* Interrupt Enable */
-    BIT(DONE),                          /* Xmit Ready */
-    BITNCF(8),                          /* unused */
-    ENDBITS
-};
-
-static BITFIELD tx_buf_bits[] = {
-    BITF(DAT,8),                        /* data buffer */
-    BITNCF(8),                          /* unused */
-    ENDBITS
-};
-
 
 /* Clock definitions */
 

--- a/VAX/vax820_ka.c
+++ b/VAX/vax820_ka.c
@@ -151,7 +151,6 @@ DEVICE ka_dev[] = {
 t_stat ka_rdreg (int32 *val, int32 pa, int32 lnt)
 {
 int32 ka, ofs;
-t_bool extmem = MEMSIZE > MAXMEMSIZE;
 
 ka = NEXUS_GETNEX (pa) - TR_KA0;                        /* get CPU num */
 ofs = NEXUS_GETOFS (pa);                                /* get offset */
@@ -194,7 +193,6 @@ return SCPE_OK;
 t_stat ka_wrreg (int32 val, int32 pa, int32 lnt)
 {
 int32 ka, ofs;
-t_bool extmem = MEMSIZE > MAXMEMSIZE;
 
 ka = NEXUS_GETNEX (pa) - TR_KA0;                        /* get CPU num */
 ofs = NEXUS_GETOFS (pa);                                /* get offset */

--- a/VAX/vax820_mem.c
+++ b/VAX/vax820_mem.c
@@ -113,7 +113,6 @@ DEVICE mctl_dev[] = {
 t_stat mctl_rdreg (int32 *val, int32 pa, int32 lnt)
 {
 int32 mctl, ofs;
-t_bool extmem = MEMSIZE > MAXMEMSIZE;
 
 mctl = NEXUS_GETNEX (pa) - TR_MCTL0;                    /* get mctl num */
 ofs = NEXUS_GETOFS (pa);                                /* get offset */
@@ -158,7 +157,6 @@ return SCPE_OK;
 t_stat mctl_wrreg (int32 val, int32 pa, int32 lnt)
 {
 int32 mctl, ofs;
-t_bool extmem = MEMSIZE > MAXMEMSIZE;
 
 mctl = NEXUS_GETNEX (pa) - TR_MCTL0;                    /* get mctl num */
 ofs = NEXUS_GETOFS (pa);                                /* get offset */

--- a/VAX/vax820_stddev.c
+++ b/VAX/vax820_stddev.c
@@ -1212,8 +1212,6 @@ return FALSE;
 
 t_stat fl_reset (DEVICE *dptr)
 {
-extern int32 sys_model;
-
 fl_ecode = 0;                                           /* clear error */
 fl_sector = 0;                                          /* clear addr */
 fl_track = 0;

--- a/VAX/vax_va.c
+++ b/VAX/vax_va.c
@@ -481,7 +481,6 @@ return data;
 void va_dga_wr (int32 pa, int32 val, int32 lnt)
 {
 int32 rg = (pa >> 1) & 0xFF;
-uint32 addr = VA_FFO_OF;
 
 if (rg <= DGA_MAXREG)
     sim_debug (DBG_DGA, &va_dev, "dga_wr: %s, %X from PC %08X\n", va_dga_rgd[rg], val, fault_PC);
@@ -552,7 +551,6 @@ int32 va_mem_rd (int32 pa)
 {
 int32 rg = (pa >> 1) & 0x7FFF;
 int32 data;
-UNIT *uptr = &va_dev.units[0];
 uint16 *qr = (uint16*) vax_vcb02_bin;
 
 if (rg >= VA_RSV_OF) {

--- a/sigma/sigma_dp.c
+++ b/sigma/sigma_dp.c
@@ -930,7 +930,6 @@ t_bool dp_end_sec (UNIT *uptr, uint32 lnt, uint32 exp, uint32 st)
 {
 uint32 cidx = uptr->UCTX;
 uint32 dva = dp_dib[cidx].dva;
-uint32 dtype = GET_DTYPE (uptr->flags);
 DP_CTX *ctx = &dp_ctx[cidx];
 
 if (st != CHS_ZBC) {                                    /* end record? */
@@ -978,7 +977,6 @@ return DVS_AUTO;
 uint32 dp_tdv_status (uint32 cidx, uint32 un)
 {
 uint32 st;
-DP_CTX *ctx = &dp_ctx[cidx];
 UNIT *dp_unit = dp_dev[cidx].units;
 t_bool on_cyl;
 
@@ -996,7 +994,6 @@ return st;
 uint32 dp_aio_status (uint32 cidx, uint32 un)
 {
 uint32 st;
-DP_CTX *ctx = &dp_ctx[cidx];
 UNIT *dp_unit = dp_dev[cidx].units;
 t_bool on_cyl;
 

--- a/sigma/sigma_mt.c
+++ b/sigma/sigma_mt.c
@@ -470,8 +470,6 @@ return SCPE_OK;
 
 t_stat mt_map_err (UNIT *uptr, t_stat st)
 {
-int32 u = uptr - mt_dev.units;
-
 switch (st) {
 
     case MTSE_FMT:                                      /* illegal fmt */
@@ -639,8 +637,6 @@ return r;
 
 t_stat mt_detach (UNIT* uptr)
 {
-uint32 un = uptr - mt_dev.units;
-
 if (!(uptr->flags & UNIT_ATTABLE))
     return SCPE_NOATT;
 uptr->UST = 0;

--- a/sim_card.c
+++ b/sim_card.c
@@ -248,6 +248,7 @@ static const uint16          ascii_to_dec_029[128] = {
 };
 
 
+#if 0 /* Unused for now. */
 static const uint16          ascii_to_hol_ebcdic[128] = {
    /* Control                              */
     0xf000,0xf000,0xf000,0xf000,0xf000,0xf000,0xf000,0xf000,    /*0-37*/
@@ -291,6 +292,7 @@ static const uint16          ascii_to_hol_ebcdic[128] = {
    /*                     X18     X78    Y18  XYT18        */
     0x604, 0x602, 0x601, 0x902, 0x806, 0x502, 0xF02,0xf000
 };
+#endif
 
 const char          sim_ascii_to_six[128] = {
    /* Control                              */


### PR DESCRIPTION
And some other warnings.

All simulators were compiled with gcc, g++, and clang++ with -Wunused-variable enabled.  All warnings except the dummy_declaration in VAX files were fixed.