### PR TITLE
TRAVIS: Update Mac build to use Xcode 12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ os:
   - linux
   - osx
 language: c
+osx_image: xcode12
 env:
   # These are supposed to match ALL in makefile.
   # Each job builds 15 simulators.


### PR DESCRIPTION
Older Xcode versions no longer work with Homebrew.  The Travis CI build has been failing for a while, and this fixes that.