### PR TITLE
sim_imd: Properly calculate IMD sectsize.

### DIFF
--- a/AltairZ80/wd179x.h
+++ b/AltairZ80/wd179x.h
@@ -1,9 +1,7 @@
 /*************************************************************************
  *                                                                       *
- * $Id: wd179x.h 1907 2008-05-21 07:04:17Z hharte $                      *
- *                                                                       *
- * Copyright (c) 2007-2008 Howard M. Harte.                              *
- * http://www.hartetec.com                                               *
+ * Copyright (c) 2007-2020 Howard M. Harte.                              *
+ * https://github.com/hharte                                             *
  *                                                                       *
  * Permission is hereby granted, free of charge, to any person obtaining *
  * a copy of this software and associated documentation files (the       *
@@ -34,9 +32,6 @@
  * Module Description:                                                   *
  *     Generic Intel 8272 Disk Controller module for SIMH.               *
  *                                                                       *
- * Environment:                                                          *
- *     User mode only                                                    *
- *                                                                       *
  *************************************************************************/
 
 extern t_stat wd179x_attach(UNIT *uptr, CONST char *cptr);
@@ -46,6 +41,7 @@ extern uint8 WD179X_Read(const uint32 Addr);
 extern uint8 WD179X_Write(const uint32 Addr, uint8 cData);
 
 extern void wd179x_external_restore(void);
+extern uint8 wd179x_get_nheads(void);
 
 #define WD179X_FDC_MSR       0   /* R=FDC Main Status Register, W=Drive Select Register */
 #define WD179X_FDC_DATA      1   /* R/W FDC Data Register */

--- a/sim_imd.h
+++ b/sim_imd.h
@@ -86,6 +86,8 @@ typedef struct {
 #define IMD_MODE_300K_MFM       4
 #define IMD_MODE_250K_MFM       5
 
+#define IMD_MAX_SECTSIZE        6
+
 #define IMD_MODE_FM(x)      (x <= IMD_MODE_250K_FM)
 #define IMD_MODE_MFM(x)     (x >= IMD_MODE_500K_MFM)
 


### PR DESCRIPTION
The ImageDisk sectsize field was incorrectly set to the number of
bytes in the sector, when it should be an index as follows:

00 =  128 bytes/sector
01 =  256 bytes/sector
02 =  512 bytes/sector
03 = 1024 bytes/sector
04 = 2048 bytes/sector
05 = 4096 bytes/sector
06 = 8192 bytes/sector

Tested disk formatting on MS-DOS 1.25, Cromemco CP/M 2.2,
Cromemco CDOS, OASIS 5.6.