### PR TITLE
makefile: Fix building with musl libc

### DIFF
--- a/makefile
+++ b/makefile
@@ -371,6 +371,12 @@ ifeq (${WIN32},)  #*nix Environments (&& cygwin)
           endif
           ifeq (ldconfig,$(shell if ${TEST} -e /sbin/ldconfig; then echo ldconfig; fi))
             LIBPATH := $(sort $(foreach lib,$(shell /sbin/ldconfig -p | grep ' => /' | sed 's/^.* => //'),$(dir $(lib))))
+            ifeq (,$(filter /lib/,$(LIBPATH)))
+              LIBPATH += /lib/
+            endif
+            ifeq (,$(filter /usr/lib/,$(LIBPATH)))
+              LIBPATH += /usr/lib/
+            endif
           endif
         endif
         LIBEXT = so


### PR DESCRIPTION
Linux systems with musl libc do not print anything upon invocation of ldconfig -p, making it so that the existing method of determining library search paths did not turn up paths that possibly contained SDL or libpcap libraries. This fixes such behaviour by automatically adding /lib and /usr/lib as library paths if they weren't found with ldconfig.

Thank you for looking at this. If there is anything I can clarify or improve, please let me know.