### PR TITLE
Intel-Systems: Remove imds and isys build targets from GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,8 @@ jobs:
           - pdp1 pdp4 pdp6 pdp7 pdp8 pdp9 pdp10 pdp10-ka pdp10-ki pdp10-kl pdp11 pdp15 vax microvax3900 microvax1 rtvax1000
           - microvax2 vax730 vax750 vax780 vax8200 vax8600 microvax2000 infoserver100 infoserver150vxt microvax3100 microvax3100e vaxstation3100m30 vaxstation3100m38 vaxstation3100m76 vaxstation4000m60
           - microvax3100m80 vaxstation4000vlc infoserver1000 nova eclipse hp2100 hp3000 i1401 i1620 s3 altair altairz80 gri i7094 ibm1130
-          - id16 id32 sds lgp h316 cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 isys8010 isys8020 isys8030 isys8024
-          - besm6 imds-210 imds-220 imds-225 imds-230 imds-800 imds-810 imlac tt2500
+          - id16 id32 sds lgp h316 cdc1700 swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500
+          - besm6 imlac tt2500
           - scelbi 3b2 i701 i704 i7010 i7070 i7080 i7090 sigma uc15 i650
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Following up on @nj7p's commit 96c32fcb80a7bd1f25f81932004de7bb43f4f7e8.