### PR TITLE
3B2: Don't clobber number of serial lines

### DIFF
--- a/3B2/3b2_ports.c
+++ b/3B2/3b2_ports.c
@@ -626,7 +626,6 @@ t_stat ports_reset(DEVICE *dptr)
         ports_conf = TRUE;
 
         if (ports_ldsc == NULL) {
-            ports_desc.lines = DEF_PORTS_CARDS * PORTS_LINES;
             ports_desc.ldsc = ports_ldsc =
                 (TMLN *)calloc(ports_desc.lines, sizeof(*ports_ldsc));
         }

--- a/3B2/3b2_ports.h
+++ b/3B2/3b2_ports.h
@@ -51,7 +51,6 @@
 #define PORTS_IPL       10
 #define PORTS_VERSION   1
 
-#define DEF_PORTS_CARDS 1
 #define MAX_PORTS_CARDS 12
 #define PORTS_LINES     4
 #define PORTS_RCV_QUEUE 5


### PR DESCRIPTION
Serial line setup was inadvertantly clobbering the number of lines on initial setup, leading to potential invalid configuration.