### PR TITLE
3B2: Do not read from detached floppy

### DIFF
--- a/3B2/3b2_if.c
+++ b/3B2/3b2_if.c
@@ -554,6 +554,12 @@ void if_write(uint32 pa, uint32 val, size_t size)
         if_state.cmd = (uint8) val;
         /* Writing to the command register always de-asserts the IRQ line */
         if_clear_irq();
+
+        if ((uptr->flags & UNIT_ATT) == 0) {
+            /* If not attached, do nothing */
+            break;
+        }
+
         if_handle_command();
         break;
     case IF_TRACK_REG:


### PR DESCRIPTION
The Rev 3 firmware does not check floppy controller status before
commanding a sector read, which can lead to calling sim_disk_rdsect()
on a detached unit. With this checkin, the simulator will no longer
attempt a read or write if the floppy unit is not attached.