### PR TITLE
H316: Fix IMP host interface.

### DIFF
--- a/H316/h316_hi.c
+++ b/H316/h316_hi.c
@@ -349,14 +349,9 @@ void hi_start_tx (uint16 line, uint16 flags)
     if (ret != SCPE_OK && ret != 66) hi_link_error(line);
   }
 
-// XXX the host interface is significantly faster... Need new math here.
-// 1822 pg 4-9 100 KBS
-
-  //   Do some fancy math to figure out how long, in RTC ticks, it would actually
-  // take to transmit a packet of this length with a real modem and phone line.
-  // Note that the "+12" is an approximation for the modem overhead, including
-  // DLE, STX, ETX and checksum bytes, that would be added to the packet.
-  nbits = (((uint32) count)*2UL + 12UL) * 8UL;
+  // Do some fancy math to figure out how long, in RTC ticks, it would actually
+  // take to transmit a message of this length with a real host interface.
+  nbits = ((uint32) count)*16UL;
   PHIDB(line)->txdelay = (nbits * 1000000UL) / (PHIDB(line)->bps * rtc_interval);
   sim_debug(IMP_DBG_IOT, PDEVICE(line), "HI%d - transmit packet, length=%d, bits=%u, interval=%u, delay=%u\n", line, count, nbits, rtc_interval, PHIDB(line)->txdelay);
   // That's it - we're done until it's time for the TX done interrupt ...

--- a/H316/h316_imp.h
+++ b/H316/h316_imp.h
@@ -206,6 +206,7 @@ typedef struct _HIDB HIDB;
 // modem transmitter timing exactly right!
 extern uint32 rtc_interval;
 extern t_stat mi_tx_service (uint32 quantum);
+extern t_stat hi_tx_service (uint32 quantum);
 
 // Prototypes for UDP modem/host interface emulation routines ...
 #define NOLINK  (-1)

--- a/H316/h316_rtc.c
+++ b/H316/h316_rtc.c
@@ -245,6 +245,7 @@ t_stat rtc_service (UNIT *uptr)
     SET_RTC_IRQ();
   }
   mi_tx_service(rtc_quantum);
+  hi_tx_service(rtc_quantum);
   uptr->wait = sim_rtc_calb (rtc_tps);                  /* recalibrate */
   sim_activate_after (uptr, 1000000/rtc_tps);           /* reactivate unit */
   return SCPE_OK;


### PR DESCRIPTION
I'm testing the H316 IMP host interface (h316_hi.c) and I'm fixing some problems.  I'm opening this issue as a heads-up, and a place to discuss the changes.

The IMP hardware devices were originally written by @SpareTimeGizmos.  The host interface was added by @charlesUnixPro.

I am developing a "POSIX NCP" as a testing and debug tool: https://github.com/larsbrinkhoff/linux-ncp
