### PR TITLE
3b2: Remove glibc-specific longjmp

### DIFF
--- a/3B2/3b2_defs.h
+++ b/3B2/3b2_defs.h
@@ -54,12 +54,6 @@
 #define noret void
 #endif
 
-#if defined(__GLIBC__) && !defined(__cplusplus)
-/* use glibc internal longjmp to bypass fortify checks */
-noret __libc_longjmp(jmp_buf buf, int val);
-#define longjmp __libc_longjmp
-#endif
-
 #ifndef MAX
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 #endif


### PR DESCRIPTION
At one point in the distant past, there was an unremembered
reason to prefer __libc_longjmp if it was available. It is no
longer needed, and has been removed from glibc in the most recent
versions.