### PR TITLE
H316: Remove unneeded #include in h316_udp.c.

### DIFF
--- a/H316/h316_udp.c
+++ b/H316/h316_udp.c
@@ -131,7 +131,6 @@
 #ifdef VM_IMPTIP
 #include "sim_defs.h"           // simh machine independent definitions
 #include "sim_tmxr.h"           // The MUX layer exposes packet send and receive semantics
-#include "h316_defs.h"          // H316 emulator definitions
 #include "h316_imp.h"           // ARPAnet IMP/TIP definitions
 
 // Local constants ...


### PR DESCRIPTION
The H316 has a file called h316_udp.c that implements a transport for an (ARPANET) host-IMP interface.  (Also the IMP-IMP modem links.)  The IMP was the router in the ARPANET.  Each IMP could serve up to four host computers.  So far this has been sitting unused on the IMP side.  I have tested and fixed some problems (#1085, #1087), and now I'm adding the interface to the host side.  At least two of the SIMH emulators have software for connecting to the ARPANET: PDP-10 and PDP-11.

This makes for potentially three copies of the h316_udp.c code.  Would it be possible to lift this to a common file?