### PR TITLE
3b2: Support for SVR 2.0.5 diagnostics

### DIFF
--- a/3B2/3b2_ctc.c
+++ b/3B2/3b2_ctc.c
@@ -54,6 +54,7 @@
 
 #define CTC_DIAG_CRC1 0xa4a5752f
 #define CTC_DIAG_CRC2 0xd3d20eb3
+#define CTC_DIAG_CRC3 0x0f387ce3  /* Used by SVR 2.0.5 */
 
 #define TAPE_DEV      0    /* CTAPE device */
 #define XMF_DEV       1    /* XM Floppy device */
@@ -308,7 +309,8 @@ static void ctc_cmd(uint8 cid,
          * we are expected to write results into memory at address
          * 0x200f000 */
         if (ctc_crc == CTC_DIAG_CRC1 ||
-            ctc_crc == CTC_DIAG_CRC2) {
+            ctc_crc == CTC_DIAG_CRC2 ||
+            ctc_crc == CTC_DIAG_CRC3) {
             pwrite_h(0x200f000, 0x1);   /* Test success */
             pwrite_h(0x200f002, 0x0);   /* Test Number */
             pwrite_h(0x200f004, 0x0);   /* Actual */

--- a/3B2/3b2_ports.c
+++ b/3B2/3b2_ports.c
@@ -96,6 +96,9 @@ static t_stat ports_show_queue_common(FILE *st, UNIT *uptr, int32 val,
 #define PORTS_DIAG_CRC1 0x7ceec900
 #define PORTS_DIAG_CRC2 0x77a1ea56
 #define PORTS_DIAG_CRC3 0x84cf938b
+#define PORTS_DIAG_CRC4 0x31b32383  /* Used by SVR 2.0.5 */
+#define PORTS_DIAG_CRC5 0x4be7bccc  /* Used by SVR 2.0.5 */
+#define PORTS_DIAG_CRC6 0x3197f6dd  /* Used by SVR 2.0.5 */
 
 #define LN(cid,port)   ((PORTS_LINES * ((cid) - ports_base_cid)) + (port))
 #define LCID(ln)       (((ln) / PORTS_LINES) + ports_base_cid)
@@ -301,7 +304,10 @@ static void ports_cmd(uint8 cid, cio_entry *rentry, uint8 *rapp_data)
          * 0x200f000 */
         if (ports_crc == PORTS_DIAG_CRC1 ||
             ports_crc == PORTS_DIAG_CRC2 ||
-            ports_crc == PORTS_DIAG_CRC3) {
+            ports_crc == PORTS_DIAG_CRC3 ||
+            ports_crc == PORTS_DIAG_CRC4 ||
+            ports_crc == PORTS_DIAG_CRC5 ||
+            ports_crc == PORTS_DIAG_CRC6) {
             pwrite_h(0x200f000, 0x1);   /* Test success */
             pwrite_h(0x200f002, 0x0);   /* Test Number */
             pwrite_h(0x200f004, 0x0);   /* Actual */


### PR DESCRIPTION
The CTC and PORTS pump code for System V Release 2.0.5 for the 3B2 is
different from the pump code used by SVR 3, leading to PORTS and CTC
diagnostics failing to pass when running SVR2. This change adds
support for the pump code used in SVR 2.