### PR TITLE
KA10: Fixed bug with page fault during ILDB/IDBP

### DIFF
--- a/PDP10/ks10_cty.c
+++ b/PDP10/ks10_cty.c
@@ -127,8 +127,10 @@ t_stat ctyi_svc (UNIT *uptr)
     if (Mem_read_word(CTY_IN, &buffer, 0))
         return SCPE_OK;
     sim_debug(DEBUG_DETAIL, &cty_dev, "CTY Read %012llo\n", buffer);
-    if (buffer & CTY_CHAR)
+    if (buffer & CTY_CHAR) {
+        cty_interrupt();
         return SCPE_OK;
+    }
     ch = sim_poll_kbd ();
     if (ch & SCPE_KFLAG) {
         ch = 0177 & sim_tt_inpcvt(ch, TT_GET_MODE (cty_unit[0].flags));

--- a/PDP10/ks10_kmc.c
+++ b/PDP10/ks10_kmc.c
@@ -627,7 +627,7 @@ DEVICE kmc_dev = {
     NULL,                                       /* attach routine */
     NULL,                                       /* detach routine */
     &kmc_dib,                                   /* context */
-    KMC_DIS                                     /* Flags */
+    DEV_DIS                                     /* Flags */
              | DEV_DISABLE
              | DEV_DEBUG,
     0,                                          /* debug control */

--- a/PDP10/kx10_cpu.c
+++ b/PDP10/kx10_cpu.c
@@ -644,10 +644,11 @@ MTAB cpu_mod[] = {
 /* Simulator debug controls */
 DEBTAB              cpu_debug[] = {
     {"IRQ", DEBUG_IRQ, "Debug IRQ requests"},
+#if !KS
     {"CONI", DEBUG_CONI, "Show coni instructions"},
     {"CONO", DEBUG_CONO, "Show cono instructions"},
     {"DATAIO", DEBUG_DATAIO, "Show datai and datao instructions"},
-#if KS
+#else
     {"DATA", DEBUG_DATA, "Show data transfers"},
     {"DETAIL", DEBUG_DETAIL, "Show details about device"},
     {"EXP", DEBUG_EXP, "Show exception information"},
@@ -4644,10 +4645,10 @@ st_pi:
                     dev_irq[f] = 0;
                     break;
                 }
-#if DEBUG
-                sim_debug(DEBUG_IRQ, &cpu_dev, "vect irq %o %06o\n", pi_enc, AB);
-#endif
             }
+#if DEBUG
+            sim_debug(DEBUG_IRQ, &cpu_dev, "vect irq %o %06o\n", pi_enc, AB);
+#endif
         }
 #if KS_ITS
         pi_act |= pi_mask;
@@ -6509,7 +6510,7 @@ ld_exe:
                       AR |= BR & MQ;
                       MB = AR & FMASK;
                       if (Mem_write(0, 0))
-                         goto last;
+                          goto last;
                   }
                   FLAGS &= ~BYTI;
                   BYF5 = 0;
@@ -8167,8 +8168,6 @@ mul_done:
                   if (sim_interval <= 0) {
                       if ((reason = sim_process_event()) != SCPE_OK) {
                           f_pc_inh = 1;
-                          f_load_pc = 0;
-                          f_inst_fetch = 0;
                           set_reg(AC, AR);
                           break;
                       }
@@ -8177,8 +8176,6 @@ mul_done:
                           pi_rq = check_irq_level();
                           if (pi_rq) {
                               f_pc_inh = 1;
-                              f_load_pc = 0;
-                              f_inst_fetch = 0;
                               set_reg(AC, AR);
                               break;
                           }
@@ -11367,8 +11364,6 @@ its_wr:
                                if (sim_interval <= 0) {
                                    if ((reason = sim_process_event()) != SCPE_OK) {
                                        f_pc_inh = 1;
-                                       f_load_pc = 0;
-                                       f_inst_fetch = 0;
                                        set_reg(AC, AR);
                                        break;
                                    }
@@ -11377,8 +11372,6 @@ its_wr:
                                        pi_rq = check_irq_level();
                                        if (pi_rq) {
                                            f_pc_inh = 1;
-                                           f_load_pc = 0;
-                                           f_inst_fetch = 0;
                                            set_reg(AC, AR);
                                            break;
                                        }
@@ -11879,6 +11872,7 @@ last:
         PC = MB & RMASK;
         xct_flag = 0;
         f_load_pc = 1;
+        f_inst_fetch = 1;
         f_pc_inh = 1;
     }
 #endif
@@ -11944,6 +11938,7 @@ last:
         xct_flag = 0;
         f_load_pc = 1;
         f_pc_inh = 1;
+        f_inst_fetch = 1;
         if (pi_cycle) {
             pi_cycle = 0;
             FM[(7 << 4) | 2] = fault_data;

--- a/PDP10/kx10_defs.h
+++ b/PDP10/kx10_defs.h
@@ -584,7 +584,6 @@ void    uba_set_irq(DIB *dibp, int vect);
 void    uba_clr_irq(DIB *dibp, int vect);
 t_addr  uba_get_vect(t_addr addr, int lvl, int dev);
 void    uba_set_parity(uint16 ctl);
-uint16  uba_rh_vect(struct pdp_dib *dibp);
 int     uba_rh_read(DEVICE *dptr, t_addr addr, uint16 *data, int32 access);
 int     uba_rh_write(DEVICE *dptr, t_addr addr, uint16 data, int32 access);
 void    uba_reset();


### PR DESCRIPTION
 Fixed page fault issue during ILDBP/IDBP.
 Set KMC default state to disabled.