### PR TITLE
DISK: Fix off by one error in reporting RSTS file structure info

### DIFF
--- a/sim_disk.c
+++ b/sim_disk.c
@@ -1952,7 +1952,7 @@ if (uar != 0) {
                             }
                     }
         scanDone:
-            *result = (t_offset)(blocks + 1) * context->pcs;
+            *result = ((t_offset)(blocks + 1) * context->pcs) - 1;
             return SCPE_OK;
             }
         }


### PR DESCRIPTION
This fixes issue #1106 -- the last sector number reported was
off by one (sector past the last free sector).