### PR TITLE
sim_imd: Check for EOF when reading the IMD header

### DIFF
--- a/sim_imd.c
+++ b/sim_imd.c
@@ -119,7 +119,7 @@ static t_stat diskParse(DISK_INFO *myDisk, uint32 isVerbose)
     uint8 sectorHeadMap[256];
     uint8 sectorCylMap[256];
     uint32 sectorSize, sectorHeadwithFlags, sectRecordType;
-    uint32 i;
+    uint32 hdrBytes, i;
     uint8 start_sect;
 
     uint32 TotalSectorCount = 0;
@@ -150,9 +150,15 @@ static t_stat diskParse(DISK_INFO *myDisk, uint32 isVerbose)
     do {
         sim_debug(myDisk->debugmask, myDisk->device, "start of track %d at file offset %ld\n", myDisk->ntracks, ftell(myDisk->file));
 
-        if (sim_fread(&imd, 1, 5, myDisk->file) != 5) {
-            return (SCPE_OPENERR);
-        }
+        hdrBytes = sim_fread(&imd, 1, 5, myDisk->file);
+  
+	   if (hdrBytes == 0 && feof(myDisk->file))
+		  break;
+
+	   if (hdrBytes != 5) {
+		  sim_printf("SIM_IMD: Header read returned %d bytes instead of 5.\n", hdrBytes);
+		  return (SCPE_OPENERR);
+	   }
 
         if (feof(myDisk->file))
             break;

--- a/sim_imd.c
+++ b/sim_imd.c
@@ -152,16 +152,16 @@ static t_stat diskParse(DISK_INFO *myDisk, uint32 isVerbose)
 
         hdrBytes = sim_fread(&imd, 1, 5, myDisk->file);
   
-	   if (hdrBytes == 0 && feof(myDisk->file))
-		  break;
+	if (hdrBytes == 0 && feof(myDisk->file))
+            break; /*AGN detected end of IMD file */
 
-	   if (hdrBytes != 5) {
-		  sim_printf("SIM_IMD: Header read returned %d bytes instead of 5.\n", hdrBytes);
-		  return (SCPE_OPENERR);
-	   }
+        if (hdrBytes != 5) {
+            sim_printf("SIM_IMD: Header read returned %d bytes instead of 5.\n", hdrBytes);
+            return (SCPE_OPENERR);
+        }
 
         if (feof(myDisk->file))
-            break;
+            break; /*AGN this may no longer be needed now we're check it above */
         sectorSize = 128 << (imd.sectsize & 0x1f);
         sectorHeadwithFlags = imd.head; /*AGN save the head and flags */
         imd.head &= 1 ; /*AGN mask out flag bits to head 0 or 1 */


### PR DESCRIPTION
The recent change to check that the IMD file track header is 5 bytes was attempting to read beyond the end-of-file, resulting in a spurious file open error and (under AltairZ80) a I8272: IMD disk corrupt diagnostic.

This change exits the IMD file parse if the sim_fread returns 0 bytes and the end-of-file is reached.