### PR TITLE
sim_imd: Check for EOF when reading IMD track headers

### DIFF
--- a/sim_imd.c
+++ b/sim_imd.c
@@ -119,7 +119,7 @@ static t_stat diskParse(DISK_INFO *myDisk, uint32 isVerbose)
     uint8 sectorHeadMap[256];
     uint8 sectorCylMap[256];
     uint32 sectorSize, sectorHeadwithFlags, sectRecordType;
-    uint32 i;
+    uint32 hdrBytes, i;
     uint8 start_sect;
 
     uint32 TotalSectorCount = 0;
@@ -150,7 +150,13 @@ static t_stat diskParse(DISK_INFO *myDisk, uint32 isVerbose)
     do {
         sim_debug(myDisk->debugmask, myDisk->device, "start of track %d at file offset %ld\n", myDisk->ntracks, ftell(myDisk->file));
 
-        if (sim_fread(&imd, 1, 5, myDisk->file) != 5) {
+        hdrBytes = sim_fread(&imd, 1, 5, myDisk->file);
+  
+        if ((hdrBytes == 0) && feof(myDisk->file))
+            break; /* detected end of IMD file */
+
+        if (hdrBytes != 5) {
+            sim_printf("SIM_IMD: Header read returned %d bytes instead of 5.\n", hdrBytes);
             return (SCPE_OPENERR);
         }
 


### PR DESCRIPTION
The recent change to check that the IMD file track header record is 5
bytes introduced a problem with the end-of-file triggering an open file
error - instead of the previous behaviour where the number of bytes in
the track header was ignored and end-of-file was checked.

I noticed this after fetching and compiling the latest simh altairz80 - it
was refusing to my mount floppy disk IMD image files (which I had made
from 8-inch floppies back in 2006).

```
maxi:s100 tony$ altairz80 cpm3bk.ini

Altair 8800 (Z80) simulator V4.0-0 Current        simh git commit id: d3f1ee09
Console escape is CTRL-\
I8272: IMD disk corrupt.
/Users/tony/s100/cpm3bk.ini-58> att disk1a0 /Users/tony/s100/C3BKSIMH.IMD
File open error
```

Looking at the commit history, I saw the change by Howard Harte to
sim_imd.c to "Resolve CID 1502448, 1502460" - presumably to fix the
call to sim_fread() that was not checking the returned result.
Howard's "fix" broke the parsing of the IMD file sector headers by
not checking for an end-of-file condition (at the end of file it
would read 0 bytes and this was now treated as a fatal error - whereas
the old code had a check for end-of-file after the call to sim_fread()).

This commit now detects end-of-file correctly, as well as verifying
the track header is 5 bytes.