### PR TITLE
[doc] build dependencies for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,7 +646,7 @@ Ubuntu/Debian:
 
 Fedora/RedHat:
 
-    # yum install gcc libpcap-devel libpcre3-dev libedit-devel SDL2-devel libpng-devel zlib-devel SDL2_ttf-devel
+    # yum install gcc libpcap-devel pcre-devel libedit-devel SDL2-devel libpng-devel zlib-devel SDL2_ttf-devel which
 
 ###### NetBSD - Dependencies
 


### PR DESCRIPTION
I recently compiled SIMH in Fedora and found some improvements for the documentation:
1.) The mentioned package for `libpcre3-devel` does not exist. I think this should be `pcre-devel` for Fedora-like OS.
```
# yum install libpcre3-dev
No match for argument: libpcre3-dev
Error: Unable to find a match: libpcre3-dev
# yum info pcre-devel
Installed Packages
Name         : pcre-devel
Version      : 8.45
Release      : 1.fc38.3
Architecture : x86_64
Size         : 1.7 M
Source       : pcre-8.45-1.fc38.3.src.rpm
Repository   : @System
From repo    : fedora
```

In RHEL8, I also see the package called `pcre-devel`
```
# cat /etc/redhat-release
Red Hat Enterprise Linux release 8.7 (Ootpa)
# yum install libpcre3-dev
No match for argument: libpcre3-dev
Error: Unable to find a match: libpcre3-dev
# yum info pcre-devel
Name         : pcre-devel
Version      : 8.42
Release      : 6.el8
Architecture : x86_64
Size         : 551 k
Source       : pcre-8.42-6.el8.src.rpm
Repository   : rhel-8-for-x86_64-baseos-rpms
```
2.) There is a build dependency on `which` command. This is likely part of most Linux OS installs, but in the containerized Fedora 38 [`docker.io/library/fedora:38`] it is not present.
```	
$ make pdp8
*** Warning *** Using local cc since gcc isn't available locally.
*** Warning *** You may need to install gcc to build working simulators.
make: which: No such file or directory
makefile:339: *** building using a git repository, but git is not available.  Stop.
```
In this case, gcc and git are installed, but the makefile cannot detect them.
I found the makefile explicitly calls out to `which`, so my opinion is that we should include it as a build dependency. Ex:
https://github.com/simh/simh/blob/22e33dd3d4aef3b558d82d95801c296caddb314a/makefile#L330-L333
https://github.com/simh/simh/blob/22e33dd3d4aef3b558d82d95801c296caddb314a/makefile#L419-L423

Please let me know your opinion & any further testing required.