### PR TITLE
[doc] build dependencies for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ Different Linux distributions have different package management systems:
 
 Ubuntu/Debian:
 
-    # apt-get install gcc libpcap-dev libvdeplug-dev libpcre3-dev libedit-dev libsdl2-dev libpng-dev libsdl2_ttf-dev
+    # apt-get install gcc libpcap-dev libvdeplug-dev libpcre3-dev libedit-dev libsdl2-dev libpng-dev libsdl2-ttf-dev
 
 Fedora/RedHat:
 


### PR DESCRIPTION
- There's no package named `libsdl2_ttf-dev`, but `libsdl2-ttf-dev`
- Fixing [`README.md`](https://github.com/simh/simh/blob/37bc857bf14e37d66b21cc7b93022823218c7a3f/README.md#L646)

## References
- https://packages.debian.org/en/sid/libsdl2-ttf-dev
- https://packages.ubuntu.com/en/focal/libsdl2-ttf-dev