### PR TITLE
correct logic error in build_vstudio.bat for VS2022 and v141_xp

### DIFF
--- a/build_vstudio.bat
+++ b/build_vstudio.bat
@@ -193,6 +193,7 @@ if not "%_VC_VER%" == "2022" goto _RunBuild
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v150\Platforms\x64\PlatformToolsets\v141_xp" goto _DoXPConvert
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Professional\MSBuild\Microsoft\VC\v150\Platforms\x64\PlatformToolsets\v141_xp" goto _DoXPConvert
 if exist "%ProgramFiles%\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v150\Platforms\x64\PlatformToolsets\v141_xp" goto _DoXPConvert
+goto _RunBuild
 :_DoXPConvert
 set _X_PROJS_CONVERTED=
 for /F "usebackq tokens=1" %%a in (`findstr /C:"<WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>" "%_BUILD_PROJECT_DIR%BuildROMs.vcxproj"`) do set _X_PROJS_CONVERTED=%%a


### PR DESCRIPTION
``build_vstudio.bat`` converts the ``.vcproj`` files from Visual Studio 2008 to ``.vcxproj`` when used with newer versions of Visual Studio and configures it to build XP-compatible binaries using the ``v141_xp`` toolset. However, this toolset is deprecated and may not be present when using Visual Studio 2022. The script intends to edit the ``.vcxproj`` files only in the case where it exists; however, due to a logic error it actually does this unconditionally. This causes the build to fail on VS2022 when the XP toolset is not present.