### PR TITLE
VIDEO: Add vid_render_set_logical_size() stub

### DIFF
--- a/sim_video.c
+++ b/sim_video.c
@@ -3061,6 +3061,11 @@ void vid_set_window_size (VID_DISPLAY *vptr, int32 w, int32 h)
 return;
 }
 
+void vid_render_set_logical_size (VID_DISPLAY *vptr, int32 w, int32 h)
+{
+return;
+}
+
 const char *vid_key_name (uint32 key)
 {
 return "";


### PR DESCRIPTION
Fixes oversite of missing sim_video stub function.