### PR TITLE
exit on tty EOF after SIGHUP

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -3368,7 +3368,7 @@ while (stat != SCPE_EXIT) {                             /* in case exit */
         sim_cptr_is_action[sim_do_depth] = FALSE;
         }
     if (cptr == NULL) {                                 /* EOF? or SIGINT? */
-        if (sim_ttisatty()) {
+        if (sim_ttisatty() && (!sigterm_received)) {
             printf ("\n");
             continue;                                   /* ignore tty EOF */
             }
@@ -10238,7 +10238,11 @@ else
 void int_handler (int sig)
 {
 stop_cpu = TRUE;
-if (sig == SIGTERM)
+if ((sig == SIGTERM)
+#ifdef SIGHUP
+    || (sig == SIGHUP)
+#endif
+   )
     sigterm_received = TRUE;
 sim_interval = 0;               /* Minimize when stop_cpu gets noticed */
 }


### PR DESCRIPTION
Currently, ```SIGTERM``` is caught and causes execution to stop, for graceful termination of a simulation. (As an example ```systemd``` by default stops a service with ```SIGTERM```.) This provides an opportunity for an ```.ini``` script to clean up. Rads are attempted from the terminal when the end of the ```.ini``` file is reached. However, there may no longer be a terminal to read from, in which case the reads will return 0 (EOF) - and will be retried forever.

If ```SIGHUP``` is defined (as it is on a *nix system), then it is configured the same as ```SIGTERM```. The apparent intent is to handle cases where this signal indicates that the process should shut down, such as the termination of a terminal session (```screen```, ```tmux```, or dialup modem hanging up :-)). However, the handler ```int_handler``` only treats ```SIGTERM``` as a special case. Effectively, ```SIGHUP``` is handled the same as ```SIGINT```: simuation stops, but the signal handlers for ```SIGHUP``` and ```SIGTERM``` are reset to ```SIG_DFL```, so that another one of these signals will immediately terminate the process.

This pull request makes two changes:
1. Treat ```SIGHUP``` like ```SIGTERM``` in ```int_handler```, notably, set ```sigterm_received``` to 1 when either of these signals is received.
2. If ```sigterm_received``` is non-zero, exit if an EOF is read from the tty.

With these changes, if simh is terminated with either of these signals it will gracefully clean up (with a suitable ```.ini``` file) and then exit without going into an infinite loop reading EOF from the tty.