### PR TITLE
Reverted tape mark behaviour as revision was wrong (Van Snyder)

### DIFF
--- a/I1401/i1401_mt.c
+++ b/I1401/i1401_mt.c
@@ -25,6 +25,7 @@
 
    mt           7-track magtape
 
+   15-Aug-25    VRS     Reverted tape mark behaviour as revision was wrong (Van Snyder)
    26-Mar-22    RMS     Added extra case points for new MTSE definitions
    20-Oct-16    RMS     Must call sim_tape_attach to use library (Mark Pizzolato)
    03-Sep-13    RMS     Read TMK does not write GM+WM to memory
@@ -346,8 +347,6 @@ switch (mod) {
                 return STOP_WRAP;
                 }
             }
-        if (st == MTSE_TMK)                             /* if TMK, no GM+WM */
-            break;
         if (M[BS] != (BCD_GRPMRK + WM)) {               /* not GM+WM at end? */
             if (flag & MD_WM)                           /* LCA: clear WM */
                 M[BS] = BCD_GRPMRK;


### PR DESCRIPTION
I talked to Van Snyder and he told me about this "fix" he wanted introduced in SimH i1401. The fix was needed to get a program running. The program not working was likely due to a transcription error, not the emulator. This "fix" thus introduced a bug, which this pull request will fix.

Currently SimH i1401 doesn't deposit a group mark in core memory after reading a tape mark. It only deposits the tape mark. This is wrong. The tape mark should be followed by a group mark.