### PR TITLE
AltairZ80: wd179x: better support for raw DSK images.

### DIFF
--- a/AltairZ80/wd179x.h
+++ b/AltairZ80/wd179x.h
@@ -41,6 +41,7 @@ extern uint8 WD179X_Set_DMA(const uint32 dma_addr);
 extern uint8 WD179X_Read(const uint32 Addr);
 extern uint8 WD179X_Write(const uint32 Addr, uint8 cData);
 
+extern void wd179x_set_rpm(int rpm);
 extern void wd179x_external_restore(void);
 extern uint8 wd179x_get_nheads(void);
 


### PR DESCRIPTION
IMD images are difficult to work with when restoring media and manually editing sector data. Raw disk images are much easier to work with. WD179x currently only supports IBM 3740 SSSD raw DSK images.

This PR enhances DSK image support by creating IMD records when attaching DSK images. This also simplifies the code as now all disk images appear to be IMD format.

DSK to IMD conversion is determined through a table. Additional formats can easily be added to the table.

This PR passes all the AltairZ80 automated tests on Mac:

CompuPro CP/M-80
CompuPro CP/M-86
SCP 86-DOS
MS-DOS 2.11 - Builds MS-DOS 2.11 from source.
CompuPro CP/M-68K v1.3 (68000 and 68010 versions)
CP/M-68K v1.2
Advanced Digital Super-Six CP/M 2.2
Advanced Digital Super-Six CP/M 3.0
DIGITEX CP/M 2.2
DIGITEX CP/M 3.0
DIGITEX OASIS multi-user version 5.6
MultiStar: IBC OASIS multi-user version 5.6
MegaStar: IBC OASIS multi-user version 5.6
CP/M-80 (Altair) ZEXALL Z80 instruction set test.
CP/M 3 (Altair) Banked Memory Test.