### PR TITLE
fix null pointer dereference when SHOWing cpu register

### DIFF
--- a/scp.c
+++ b/scp.c
@@ -2977,6 +2977,7 @@ if (vm_flag || ((reason = fprint_sym (sim_tmpfile, addr, val, uptr, sw)) > 0)) {
     reason = dfltinc;
     }
 sim_mfile = NULL;
+mbuf.buf[MIN(mbuf.pos,511)] = '\0'; /* ensure null termination */
 strlcpy (buf, mbuf.buf, MIN(bufsize, mbuf.pos + 1));
 free (mbuf.buf);
 return reason;
@@ -17989,3 +17990,4 @@ for (i = 0; (dptr = sim_devices[i]) != NULL; i++) {
     }
 return stat;
 }
+

--- a/scp.c
+++ b/scp.c
@@ -6777,6 +6777,7 @@ else {
                          (mptr->pstring && (MATCH_CMD (gbuf, mptr->pstring) == 0))) ||
                         (!(mptr->mask & MTAB_VDV) && (mptr->mstring && (MATCH_CMD (gbuf, mptr->mstring) == 0)))) {
                         dptr = sim_dflt_dev;
+                        uptr = dptr->units;
                         lvl = MTAB_VDV;                 /* device match */
                         cptr = svptr;
                         while (sim_isspace(*cptr))


### PR DESCRIPTION
When doing a SHOW of a CPU register, ``show_cmd_fi`` sets ``dptr`` to ``sim_dflt_dev`` (the CPU) but doesn't set ``uptr``. Previously this was OK; however, there is new code that that depends upon ``uptr`` being non-NULL. As an example, doing a ``show history`` in a PDP11 simulator will crash with a segmentation violation.

A second, less serious, problem is that ``sim_snprint_sym`` doesn't null-terminate the buffer it passes to ``strlcpy``. ``strlcpy`` expects the source string to be null terminated. In this case, the destination size is always less than or equal to the length of the source string, so the result is well-formed (and null-terminated). However, ``strlcpy`` will look for the end of the source string in order to return its length. ``sim_snprint_sym`` doesn't depend upon this, so usually this is not a problem. However, when ``strlcpy`` goes past the end of the source it could land in unallocated memory. (As an example, this happens when simh is run on Windows with app verifier.) The fix is to ensure that there is always a null byte at the end of the source string.