### PR TITLE
fix out of bounds uptr in PDP10/kx10_dp.c dp_devio()

### DIFF
--- a/PDP10/kx10_dp.c
+++ b/PDP10/kx10_dp.c
@@ -459,10 +459,8 @@ t_stat dp_devio(uint32 dev, uint64 *data) {
                  df10->status &= ~PI_ENABLE;
              else
                  df10_setirq(df10);
-         }
-
-         /* If setting the interrupt value and done set trigger IRQ */
-         if ((uptr->UFLAGS & DONE) != 0) {
+         } else if ((uptr->UFLAGS & DONE) != 0) {
+            /* If setting the interrupt value and done set trigger IRQ */
             df10_setirq(df10);
          }
   


### PR DESCRIPTION
When booting TOPS10 on the pdp10-ka simulator, booting will often hang at the point where it detects which disk drives are offline. The root cause is a code path in the function ``dp_devio`` (within ``PDP10/kx10_dp.c``) that uses ``uptr`` to iterate through all of the units associated with the current controller, leaving it pointing beyond the last ``UNIT``. This can cause a problem with later code that checks whether ``uptr->STATUS`` has the ``DONE`` bit set - but ``uptr`` is not meaningful.

However, ``DONE`` can never be set when ``PI_ENABLE`` is set, so the two code blocks are mutually exclusive. The fix is to structure them as an if-then-elseif rather than two sequential if blocks.