### PR TITLE
reverse dependency between pdp11 and pidp11-frontpanel

### DIFF
--- a/makefile
+++ b/makefile
@@ -250,8 +250,8 @@ endif
 ifneq (,$(or $(findstring pdp8,${MAKECMDGOALS}),$(findstring sds,${MAKECMDGOALS})))
   VIDEO_USEFUL = true
 endif
-# building the PDP11 on certain platforms (Raspberry Pi) could use gpio support
-ifneq (,$(findstring pdp11,${MAKECMDGOALS}))
+# building the PiDP11 front panel on certain platforms (Raspberry Pi) could use gpio support
+ifneq (,$(findstring pidp11-frontpanel,${MAKECMDGOALS}))
   GPIO_USEFUL = true
 endif
 # building the pdp11, any pdp10, any 3b2, or any vax simulator could use networking support
@@ -2643,7 +2643,7 @@ ALL = pdp1 pdp4 pdp7 pdp8 pdp9 pdp15 pdp11 pdp10 \
 	swtp6800mp-a swtp6800mp-a2 tx-0 ssem b5500 intel-mds \
 	scelbi 3b2 3b2-700 i701 i704 i7010 i7070 i7080 i7090 \
 	sigma uc15 pdp10-ka pdp10-ki pdp10-kl pdp10-ks pdp6 i650 \
-	imlac linc tt2500 sel32
+	imlac linc tt2500 sel32 $(if $(GPIO_AVAILABLE),pidp11-frontpanel)
 
 all : ${ALL}
 
@@ -2733,19 +2733,23 @@ $(BIN)tt2500$(EXE) : ${TT2500} ${SIM}
 	$(MAKEIT) OPTS="$(TT2500_OPT)"
 
 
-pdp11 : $(BIN)pdp11$(EXE) $(if $(GPIO_AVAILABLE),pidp11-frontpanel)
+pdp11 : $(BIN)pdp11$(EXE)
 
 $(BIN)pdp11$(EXE) : ${PDP11} ${SIM} ${BUILD_ROMS}
 	$(MAKEIT) OPTS="$(PDP11_OPT)"
 
-pidp11-frontpanel : $(BIN)pidp11-frontpanel$(EXE)
+pidp11-frontpanel : pdp11 $(BIN)pidp11-frontpanel$(EXE)
 
 $(BIN)pidp11-frontpanel$(EXE) : 
+ifneq (,$(GPIO_AVAILABLE))
 	mkdir -p $(BIN)frontpanels/ && test ! -d $(BIN)frontpanels/pidp11-frontpanel && git clone https://github.com/hammurabi-mendes/pidp-frontpanel $(BIN)frontpanels/pidp11-frontpanel
 	cp $(BIN)../sim_frontpanel.* $(BIN)frontpanels/pidp11-frontpanel/
 	cp $(BIN)../sim_sock.* $(BIN)frontpanels/pidp11-frontpanel/
 	sed -i 's/sim_panel_destroy.simh_panel/sim_panel_destroy\(\&simh_panel/g' $(BIN)frontpanels/pidp11-frontpanel/frontpanel.cpp
 	cd $(BIN)frontpanels/pidp11-frontpanel/ && make && cp frontpanel ../../pidp11-frontpanel
+else
+	$(error pidp11-frontpanel only builds on Raspberry Pi)
+endif
 
 uc15 : $(BIN)uc15$(EXE)
 


### PR DESCRIPTION
A recent commit added a new ``pidp11-frontpanel`` build target. If the build environment is a Raspberry Pi, then when building ``pdp11`` this new build target is also built. There are several concerns with this approach:
1. This makes ``pdp11`` dependent upon ``pidp11-frontpanel``, so that on a Raspberry Pi it is not possible to build ``pdp11`` without also building ``pidp11-frontpanel``. This creates excess unnecessary work (cloning the ``pidp11-frontpanel`` repo and building it even if not needed).
2. There is a breaking change across versions of libgpiod. The API is completely different in libgpiod2 than in libgpiod3. As a result, libgpiod-dev is different across different Debian releases. Specifically, ``pidp11-frontpanel`` uses the newer API and will only build successfully on a Raspberry Pi running Trixie; it will fail on Bookworm (or older) releases, which are still in widespread use. This means that on an older Raspberry Pi, building ``pdp11`` will fail because it depends upon ``pidp11-frontpanel`` -- and that will fail to build.
3. ``GPIO_USEFUL`` is true if the build target is ``pdp11``, but the ``pdp11`` build target doesn't depend upon GPIO; instead, ``pidp11-frontpanel`` does.


The proposed solution is to reverse the dependency so that ``pidp11-frontpanel`` depends upon ``pdp11`` (rather than the other way around). GPIO support is conditioned on the ``pidp11-frontpanel`` build target, not upon ``pdp11``. Add ``pidp11-frontpanel`` to the ``all`` target if and only if ``GPIO_AVAILABLE`` is true.

A fix to ``pidp11-frontpanel`` for the libgpiod breaking change (so that it builds more widely on Raspberry Pi) is outside of the scope of this repository.