### PR TITLE
AltairZ80: a SET CPU SWITCHER machine loses every page above 64K

### DIFF
--- a/AltairZ80/altairz80_cpu.c
+++ b/AltairZ80/altairz80_cpu.c
@@ -7190,8 +7190,13 @@ static t_stat set_size(uint32 size, t_bool unmap) {
             sim_printf("Setting memory size to %ikB ignored for M68K.\n", size);
         return SCPE_OK;
     }
+    /* A CPU switcher board such as the CompuPro CPU 85/88 shares one S-100
+       memory space between both processors: the 8085 side only reaches 64K
+       of it, but the 8088 side and the DMA controllers use the full
+       megabyte, so the size must not be clamped to one bank here. */
     maxsize = (((chiptype == CHIP_TYPE_8080) || (chiptype == CHIP_TYPE_Z80)) &&
-               ((cpu_unit.flags & UNIT_CPU_BANKED) == 0)) ? MAXBANKSIZE : MAXMEMORY;
+               ((cpu_unit.flags & (UNIT_CPU_BANKED | UNIT_CPU_SWITCHER)) == 0)) ?
+               MAXBANKSIZE : MAXMEMORY;
     size <<= KBLOG2;
     if (cpu_unit.flags & UNIT_CPU_BANKED)
         size &= ~ADDRMASK;


### PR DESCRIPTION
## How this was found

Booting a CompuPro System 8/16 in AltairZ80. That machine has a CPU 85/88,
where an 8085 and an 8088 take turns on one S-100 bus and a read of the swap
port at `FD` hands the bus over, which is exactly what `SET CPU SWITCHER`
models.

The machine printed nothing at all. Not a banner, not a character. The boot
ROM ran, the floppy was read, and then the 8088 came up executing empty
memory.

The reason is in `set_size()`:

```c
maxsize = (((chiptype == CHIP_TYPE_8080) || (chiptype == CHIP_TYPE_Z80)) &&
           ((cpu_unit.flags & UNIT_CPU_BANKED) == 0)) ? MAXBANKSIZE : MAXMEMORY;
```

On a switcher machine the current chip is a Z80 when you configure it, so
`SET CPU MEMORY=1024K` was clamped to one bank and every page above 64K was
left marked as non-existent. Switching to the 8086 later does raise
`MEMORYSIZE` to `MAXMEMORY`, but it never maps those pages, so `SHOW CPU`
happily reports 1MB while reads return `FF` and writes go nowhere:

```
sim> show cpu
        1MB, NOITRAP, 8086, AZ80, STOPONHALT
        MMU, SWITCHER=0xfd, NOPO
sim> deposit fff80 55
sim> examine fff80
FFF80:  FF
```

## Why it matters

This is not a corner case on the CompuPro 8/16. Its boot loader runs on the
8085, and the last thing it does before swapping processors is have the floppy
controller DMA one sector to `0FFF80h`, so that the 8088 finds a `JMPF` at its
reset vector:

```asm
    CALL    READ$DISK   ;Re-read sector 2 into the 8088's highest RAM
    JNZ     RETRY
    LXI     H,(SWAPP * 256) + IN85
    SHLD    WAIT85      ;Put "IN" instruction at the 8085's wait point
    JMP     WAIT85      ;And go wait there
```

With the memory clamped, `FFFF0h` stayed at `FF` and the 8088 started
executing that. Which looks exactly like a dead machine.

## The fix

Treat `UNIT_CPU_SWITCHER` the way `UNIT_CPU_BANKED` is already treated. Both
processors on such a board see the same S-100 memory: the 8085 only reaches
64K of it, but the 8088 and the DMA controllers use the whole megabyte, so the
size must not be clamped to one bank.

## Testing

Three CompuPro operating systems now boot on the emulated CPU 85/88, all from
the DISK 1A boot ROM already in the tree, on 8 inch DSDD ImageDisk media:

```
CompuPro Systems CP/M 8-16  vers 1.1R

   System Memory:  63K
   TPA Base = 991:0000

  Configured for ...
1 M-Drive/H, active as   M:
Disk 1  (8 inch floppy)  A:  B:  C:  D:

A>
```

```
Concurrent CP/M-86 3.1
Copyright (C) 1983, Digital Research
Concurrent CP/M 8-16 Copyright (C) 1984, CompuPro

0A>dir
Directory for User  0:
A: CCPM     SYS : TTYS         : LPRS         : DIR      CMD
...
```

and MP/M 8-16 2.1E boots on a CPU 86/87 reporting `Total memory: 1 Megabyte`.
Every one of them stops dead right after the boot loader without this change.
Each was checked by typing `DIR` at the prompt, so the system really loads a
transient off the floppy and is not just printing a banner.

Configuration used:

```
set cpu z80
set cpu switcher
set cpu memory=1024K
set hdsk disabled
set ss1 enabled
set if3 enabled
set disk1a enabled
set disk1a0 rom
attach disk1a0 cpm816-a.imd
deposit disk1a bootstrap 0
boot disk1a
```

Two notes for anyone trying this. `SET CPU SWITCHER` has to come before
`SET CPU MEMORY`, since the flag is what lifts the clamp. And `SET HDSK
DISABLED` is needed because the HDSK pseudo device also maps port `FD`, which
is the swap port, and its reset takes the port back from the switcher. That
one is worth a separate look and is not part of this change.

## AI assistance

Written with Claude Opus 5 (model claude-opus-5, Anthropic) through Claude Code.
